### PR TITLE
Generate DDL from GraphDB

### DIFF
--- a/src/main/scala/domain/table/TableList.scala
+++ b/src/main/scala/domain/table/TableList.scala
@@ -23,4 +23,10 @@ case class TableList(private val value: Map[TableName, ColumnList]) extends AnyV
         )
       }
     }
+
+  def toSqlSentence: String =
+    value.map { case (tableName, columnList) =>
+      s"CREATE TABLE IF NOT EXISTS ${tableName.toSqlSentence} (${columnList.toSqlSentence});"
+    }.mkString("\n")
+
 }

--- a/src/main/scala/domain/table/TableName.scala
+++ b/src/main/scala/domain/table/TableName.scala
@@ -1,3 +1,5 @@
 package domain.table
 
-case class TableName(private val value: String) extends AnyVal
+case class TableName(private val value: String) extends AnyVal {
+  def toSqlSentence: String = value
+}

--- a/src/main/scala/domain/table/column/ColumnLength.scala
+++ b/src/main/scala/domain/table/column/ColumnLength.scala
@@ -5,4 +5,6 @@ case class ColumnLength(private val value: Int) {
   def max(target: ColumnLength): ColumnLength = max(target.value)
 
   def max(target: Int): ColumnLength = ColumnLength(Math.max(value, target))
+
+  def toSqlSentense: String = value.toString
 }

--- a/src/main/scala/domain/table/column/ColumnLength.scala
+++ b/src/main/scala/domain/table/column/ColumnLength.scala
@@ -6,5 +6,5 @@ case class ColumnLength(private val value: Int) {
 
   def max(target: Int): ColumnLength = ColumnLength(Math.max(value, target))
 
-  def toSqlSentense: String = value.toString
+  def toSqlSentence: String = value.toString
 }

--- a/src/main/scala/domain/table/column/ColumnList.scala
+++ b/src/main/scala/domain/table/column/ColumnList.scala
@@ -21,4 +21,9 @@ case class ColumnList(private val value: Map[ColumnName, ColumnType]) extends An
         )
       }
     }
+
+  def toSqlSentence: String =
+    value.map { case (columnName, columnType) =>
+      s"${columnName.toSqlSentence} ${columnType.toSqlSentence}"
+    }.mkString(", ")
 }

--- a/src/main/scala/domain/table/column/ColumnName.scala
+++ b/src/main/scala/domain/table/column/ColumnName.scala
@@ -1,3 +1,5 @@
 package domain.table.column
 
-case class ColumnName(private val value: String) extends AnyVal
+case class ColumnName(private val value: String) extends AnyVal {
+  def toSqlSentence: String = value
+}

--- a/src/main/scala/domain/table/column/ColumnType.scala
+++ b/src/main/scala/domain/table/column/ColumnType.scala
@@ -2,14 +2,32 @@ package domain.table.column
 
 import scala.annotation.tailrec
 
-sealed trait ColumnType
-case object ColumnTypeBoolean extends ColumnType
+sealed trait ColumnType {
+  def toSqlSentence: String
+}
+case object ColumnTypeBoolean extends ColumnType {
+  override def toSqlSentence: String = "BOOLEAN"
+}
 
-case class ColumnTypeInt(private val length: ColumnLength) extends ColumnType
-case class ColumnTypeLong(private val length: ColumnLength) extends ColumnType
-case class ColumnTypeDouble(private val length: ColumnLength) extends ColumnType
-case class ColumnTypeString(private val length: ColumnLength) extends ColumnType
-case object ColumnTypeUnknown extends ColumnType
+case class ColumnTypeInt(private val length: ColumnLength) extends ColumnType {
+  override def toSqlSentence: String = s"INT(${length.toSqlSentense})"
+}
+
+case class ColumnTypeLong(private val length: ColumnLength) extends ColumnType {
+  override def toSqlSentence: String = s"INT(${length.toSqlSentense})"
+}
+
+case class ColumnTypeDouble(private val length: ColumnLength) extends ColumnType {
+  override def toSqlSentence: String = s"INT(${length.toSqlSentense})"
+}
+
+case class ColumnTypeString(private val length: ColumnLength) extends ColumnType {
+  override def toSqlSentence: String = s"VARCHAR(${length.toSqlSentense})"
+}
+
+case object ColumnTypeUnknown extends ColumnType {
+  override def toSqlSentence: String = s"TEXT"
+}
 
 object ColumnType {
 

--- a/src/main/scala/domain/table/column/ColumnType.scala
+++ b/src/main/scala/domain/table/column/ColumnType.scala
@@ -10,19 +10,19 @@ case object ColumnTypeBoolean extends ColumnType {
 }
 
 case class ColumnTypeInt(private val length: ColumnLength) extends ColumnType {
-  override def toSqlSentence: String = s"INT(${length.toSqlSentense})"
+  override def toSqlSentence: String = s"INT(${length.toSqlSentence})"
 }
 
 case class ColumnTypeLong(private val length: ColumnLength) extends ColumnType {
-  override def toSqlSentence: String = s"INT(${length.toSqlSentense})"
+  override def toSqlSentence: String = s"INT(${length.toSqlSentence})"
 }
 
 case class ColumnTypeDouble(private val length: ColumnLength) extends ColumnType {
-  override def toSqlSentence: String = s"INT(${length.toSqlSentense})"
+  override def toSqlSentence: String = s"INT(${length.toSqlSentence})"
 }
 
 case class ColumnTypeString(private val length: ColumnLength) extends ColumnType {
-  override def toSqlSentence: String = s"VARCHAR(${length.toSqlSentense})"
+  override def toSqlSentence: String = s"VARCHAR(${length.toSqlSentence})"
 }
 
 case object ColumnTypeUnknown extends ColumnType {

--- a/src/test/scala/domain/table/TableListSpec.scala
+++ b/src/test/scala/domain/table/TableListSpec.scala
@@ -28,4 +28,19 @@ class TableListSpec extends AnyFunSpec with Matchers {
       ))
     }
   }
+
+  describe("toSqlSentence") {
+    it("success") {
+      // TODO: not use Vertex
+      val graph = TinkerFactory.createModern().traversal()
+      val vertexQuery = VertexQuery(graph)
+      val vertex = vertexQuery.getVerticesList(0, vertexQuery.countAll.toInt)
+
+      val vertexAnalyzedResult = vertex
+        .map(vertex => VertexUtility.toTableList(vertex))
+        .reduce[TableList] { case (accumulator, currentValue) => accumulator.merge(currentValue) }
+
+      vertexAnalyzedResult.toSqlSentence shouldBe "CREATE TABLE IF NOT EXISTS vertex (id INT(1), name VARCHAR(6), age INT(2), lang VARCHAR(4));"
+    }
+  }
 }

--- a/src/test/scala/domain/table/column/ColumnListSpec.scala
+++ b/src/test/scala/domain/table/column/ColumnListSpec.scala
@@ -5,19 +5,19 @@ import org.scalatest.matchers.should.Matchers
 
 class ColumnListSpec extends AnyFunSpec with Matchers {
 
-  describe("merge") {
-    val columnList1 = ColumnList(Map(
-      ColumnName("id") -> ColumnTypeInt(ColumnLength(11)),
-      ColumnName("name") -> ColumnTypeString(ColumnLength(30)),
-      ColumnName("address") -> ColumnTypeString(ColumnLength(255)),
-    ))
-    val columnList2 = ColumnList(Map(
-      ColumnName("id") -> ColumnTypeInt(ColumnLength(11)),
-      ColumnName("name") -> ColumnTypeString(ColumnLength(50)),
-      ColumnName("created_at") -> ColumnTypeUnknown,
-      ColumnName("updated_at") -> ColumnTypeUnknown,
-    ))
+  private val columnList1 = ColumnList(Map(
+    ColumnName("id") -> ColumnTypeInt(ColumnLength(11)),
+    ColumnName("name") -> ColumnTypeString(ColumnLength(30)),
+    ColumnName("address") -> ColumnTypeString(ColumnLength(255)),
+  ))
+  private val columnList2 = ColumnList(Map(
+    ColumnName("id") -> ColumnTypeInt(ColumnLength(11)),
+    ColumnName("name") -> ColumnTypeString(ColumnLength(50)),
+    ColumnName("created_at") -> ColumnTypeUnknown,
+    ColumnName("updated_at") -> ColumnTypeUnknown,
+  ))
 
+  describe("merge") {
     it("succeeds when both lists are empty") {
       ColumnList(Map.empty).merge(ColumnList(Map.empty)) shouldBe ColumnList(Map.empty)
     }
@@ -35,6 +35,12 @@ class ColumnListSpec extends AnyFunSpec with Matchers {
         ColumnName("created_at") -> ColumnTypeUnknown,
         ColumnName("updated_at") -> ColumnTypeUnknown,
       ))
+    }
+  }
+
+  describe("toSqlSentence") {
+    it("success") {
+      columnList1.merge(columnList2).toSqlSentence shouldBe "name VARCHAR(50), id INT(11), address VARCHAR(255), created_at TEXT, updated_at TEXT"
     }
   }
 }

--- a/src/test/scala/domain/table/column/ColumnTypeSpec.scala
+++ b/src/test/scala/domain/table/column/ColumnTypeSpec.scala
@@ -77,4 +77,15 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ColumnType.merge(columnTypeUnknown, columnTypeUnknown) shouldBe columnTypeUnknown
     }
   }
+
+  describe("toSqlSentence") {
+    it("success") {
+      ColumnType.apply(false).toSqlSentence shouldBe "BOOLEAN"
+      ColumnType.apply("string").toSqlSentence shouldBe "VARCHAR(6)"
+      ColumnType.apply(1).toSqlSentence shouldBe "INT(1)"
+      ColumnType.apply(1.toLong).toSqlSentence shouldBe "INT(1)"
+      ColumnType.apply(1.1).toSqlSentence shouldBe "INT(3)"
+      ColumnType.apply(Seq.empty).toSqlSentence shouldBe "TEXT"
+    }
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the application to automatically generate SQL Data Definition Language (DDL) statements for creating database tables from graph database structures.

- **Improvements**
	- Implemented methods to convert table and column information into SQL sentences, streamlining database schema generation.

- **Tests**
	- Added new test cases to ensure the correctness of the SQL sentence generation from table and column metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->