### PR TITLE
add data types by janus graph

### DIFF
--- a/src/main/scala/domain/table/ddl/column/ColumnType.scala
+++ b/src/main/scala/domain/table/ddl/column/ColumnType.scala
@@ -28,6 +28,11 @@ case class ColumnTypeLong(private val length: ColumnLength) extends ColumnType {
   override def toSqlSentence: String = s"INT(${length.toSqlSentence})"
 }
 
+case class ColumnTypeFloat(private val length: ColumnLength)
+    extends ColumnType {
+  override def toSqlSentence: String = s"FLOAT"
+}
+
 case class ColumnTypeDouble(private val length: ColumnLength)
     extends ColumnType {
   override def toSqlSentence: String = s"DOUBLE"
@@ -58,6 +63,10 @@ object ColumnType {
     case valueInt: Int => ColumnTypeInt(ColumnLength(valueInt.toString.length))
     case valueLong: Long =>
       ColumnTypeLong(ColumnLength(valueLong.toString.length))
+    case valueFloat: Float =>
+      ColumnTypeFloat(
+        ColumnLength(valueFloat.toString.replaceAll("0*$", "").length)
+      )
     case valueDouble: Double =>
       ColumnTypeDouble(
         ColumnLength(valueDouble.toString.replaceAll("0*$", "").length)
@@ -90,6 +99,8 @@ object ColumnType {
         ColumnTypeInt(length.max(5)) // 5 = false.toString
       case (ColumnTypeBoolean, ColumnTypeLong(length)) =>
         ColumnTypeLong(length.max(5)) // 5 = false.toString
+      case (ColumnTypeBoolean, ColumnTypeFloat(length)) =>
+        ColumnTypeFloat(length.max(5)) // 5 = false.toString
       case (ColumnTypeBoolean, ColumnTypeDouble(length)) =>
         ColumnTypeDouble(length.max(5)) // 5 = false.toString
       case (ColumnTypeBoolean, ColumnTypeCharacter(length)) =>
@@ -108,6 +119,8 @@ object ColumnType {
         ColumnTypeInt(alength.max(blength))
       case (ColumnTypeByte(alength), ColumnTypeLong(blength)) =>
         ColumnTypeLong(alength.max(blength))
+      case (ColumnTypeByte(alength), ColumnTypeFloat(blength)) =>
+        ColumnTypeFloat(alength.max(blength))
       case (ColumnTypeByte(alength), ColumnTypeDouble(blength)) =>
         ColumnTypeDouble(alength.max(blength))
       case (ColumnTypeByte(alength), ColumnTypeCharacter(blength)) =>
@@ -125,6 +138,8 @@ object ColumnType {
         ColumnTypeInt(alength.max(blength))
       case (ColumnTypeShort(alength), ColumnTypeLong(blength)) =>
         ColumnTypeLong(alength.max(blength))
+      case (ColumnTypeShort(alength), ColumnTypeFloat(blength)) =>
+        ColumnTypeFloat(alength.max(blength))
       case (ColumnTypeShort(alength), ColumnTypeDouble(blength)) =>
         ColumnTypeDouble(alength.max(blength))
       case (ColumnTypeShort(alength), ColumnTypeCharacter(blength)) =>
@@ -141,6 +156,8 @@ object ColumnType {
         ColumnTypeInt(alength.max(blength))
       case (ColumnTypeInt(alength), ColumnTypeLong(blength)) =>
         ColumnTypeLong(alength.max(blength))
+      case (ColumnTypeInt(alength), ColumnTypeFloat(blength)) =>
+        ColumnTypeFloat(alength.max(blength))
       case (ColumnTypeInt(alength), ColumnTypeDouble(blength)) =>
         ColumnTypeDouble(alength.max(blength))
       case (ColumnTypeInt(alength), ColumnTypeCharacter(blength)) =>
@@ -156,6 +173,8 @@ object ColumnType {
       case (ColumnTypeLong(_), ColumnTypeInt(_))   => merge(b, a)
       case (ColumnTypeLong(alength), ColumnTypeLong(blength)) =>
         ColumnTypeLong(alength.max(blength))
+      case (ColumnTypeLong(alength), ColumnTypeFloat(blength)) =>
+        ColumnTypeFloat(alength.max(blength))
       case (ColumnTypeLong(alength), ColumnTypeDouble(blength)) =>
         ColumnTypeDouble(alength.max(blength))
       case (ColumnTypeLong(alength), ColumnTypeCharacter(blength)) =>
@@ -164,12 +183,29 @@ object ColumnType {
         ColumnTypeString(alength.max(blength))
       case (ColumnTypeLong(_), ColumnTypeUnknown) => ColumnTypeUnknown
 
+      // ColumnTypeFloat
+      case (ColumnTypeFloat(_), ColumnTypeBoolean)  => merge(b, a)
+      case (ColumnTypeFloat(_), ColumnTypeByte(_))  => merge(b, a)
+      case (ColumnTypeFloat(_), ColumnTypeShort(_)) => merge(b, a)
+      case (ColumnTypeFloat(_), ColumnTypeInt(_))   => merge(b, a)
+      case (ColumnTypeFloat(_), ColumnTypeLong(_))  => merge(b, a)
+      case (ColumnTypeFloat(alength), ColumnTypeFloat(blength)) =>
+        ColumnTypeFloat(alength.max(blength))
+      case (ColumnTypeFloat(alength), ColumnTypeDouble(blength)) =>
+        ColumnTypeDouble(alength.max(blength))
+      case (ColumnTypeFloat(alength), ColumnTypeString(blength)) =>
+        ColumnTypeString(alength.max(blength))
+      case (ColumnTypeFloat(alength), ColumnTypeCharacter(blength)) =>
+        ColumnTypeCharacter(alength.max(blength))
+      case (ColumnTypeFloat(_), ColumnTypeUnknown) => ColumnTypeUnknown
+
       // ColumnTypeDouble
       case (ColumnTypeDouble(_), ColumnTypeBoolean)  => merge(b, a)
       case (ColumnTypeDouble(_), ColumnTypeByte(_))  => merge(b, a)
       case (ColumnTypeDouble(_), ColumnTypeShort(_)) => merge(b, a)
       case (ColumnTypeDouble(_), ColumnTypeInt(_))   => merge(b, a)
       case (ColumnTypeDouble(_), ColumnTypeLong(_))  => merge(b, a)
+      case (ColumnTypeDouble(_), ColumnTypeFloat(_)) => merge(b, a)
       case (ColumnTypeDouble(alength), ColumnTypeDouble(blength)) =>
         ColumnTypeDouble(alength.max(blength))
       case (ColumnTypeDouble(alength), ColumnTypeString(blength)) =>
@@ -184,6 +220,7 @@ object ColumnType {
       case (ColumnTypeCharacter(_), ColumnTypeShort(_))  => merge(b, a)
       case (ColumnTypeCharacter(_), ColumnTypeInt(_))    => merge(b, a)
       case (ColumnTypeCharacter(_), ColumnTypeLong(_))   => merge(b, a)
+      case (ColumnTypeCharacter(_), ColumnTypeFloat(_))  => merge(b, a)
       case (ColumnTypeCharacter(_), ColumnTypeDouble(_)) => merge(b, a)
       case (ColumnTypeCharacter(alength), ColumnTypeCharacter(blength)) =>
         ColumnTypeCharacter(alength.max(blength))
@@ -197,6 +234,7 @@ object ColumnType {
       case (ColumnTypeString(_), ColumnTypeShort(_))     => merge(b, a)
       case (ColumnTypeString(_), ColumnTypeInt(_))       => merge(b, a)
       case (ColumnTypeString(_), ColumnTypeLong(_))      => merge(b, a)
+      case (ColumnTypeString(_), ColumnTypeFloat(_))     => merge(b, a)
       case (ColumnTypeString(_), ColumnTypeDouble(_))    => merge(b, a)
       case (ColumnTypeString(_), ColumnTypeCharacter(_)) => merge(b, a)
       case (ColumnTypeString(alength), ColumnTypeString(blength)) =>
@@ -209,6 +247,7 @@ object ColumnType {
       case (ColumnTypeUnknown, ColumnTypeShort(_))     => merge(b, a)
       case (ColumnTypeUnknown, ColumnTypeInt(_))       => merge(b, a)
       case (ColumnTypeUnknown, ColumnTypeLong(_))      => merge(b, a)
+      case (ColumnTypeUnknown, ColumnTypeFloat(_))     => merge(b, a)
       case (ColumnTypeUnknown, ColumnTypeDouble(_))    => merge(b, a)
       case (ColumnTypeUnknown, ColumnTypeCharacter(_)) => merge(b, a)
       case (ColumnTypeUnknown, ColumnTypeString(_))    => merge(b, a)

--- a/src/main/scala/domain/table/ddl/column/ColumnType.scala
+++ b/src/main/scala/domain/table/ddl/column/ColumnType.scala
@@ -15,6 +15,11 @@ case class ColumnTypeByte(private val length: ColumnLength) extends ColumnType {
   override def toSqlSentence: String = s"TINYINT(${length.toSqlSentence})"
 }
 
+case class ColumnTypeShort(private val length: ColumnLength)
+    extends ColumnType {
+  override def toSqlSentence: String = s"SMALLINT(${length.toSqlSentence})"
+}
+
 case class ColumnTypeInt(private val length: ColumnLength) extends ColumnType {
   override def toSqlSentence: String = s"INT(${length.toSqlSentence})"
 }
@@ -48,6 +53,8 @@ object ColumnType {
     case _: Boolean => ColumnTypeBoolean
     case valueByte: Byte =>
       ColumnTypeByte(ColumnLength(valueByte.toString.length))
+    case valueShort: Short =>
+      ColumnTypeShort(ColumnLength(valueShort.toString.length))
     case valueInt: Int => ColumnTypeInt(ColumnLength(valueInt.toString.length))
     case valueLong: Long =>
       ColumnTypeLong(ColumnLength(valueLong.toString.length))
@@ -55,8 +62,7 @@ object ColumnType {
       ColumnTypeDouble(
         ColumnLength(valueDouble.toString.replaceAll("0*$", "").length)
       )
-    case _: Char =>
-      ColumnTypeCharacter(ColumnLength(1))
+    case _: Char => ColumnTypeCharacter(ColumnLength(1))
     case valueString: String =>
       ColumnTypeString(ColumnLength(valueString.length))
     case _ => ColumnTypeUnknown // TODO: classify the type in detail
@@ -78,6 +84,8 @@ object ColumnType {
       case (ColumnTypeBoolean, ColumnTypeBoolean) => ColumnTypeBoolean
       case (ColumnTypeBoolean, ColumnTypeByte(length)) =>
         ColumnTypeByte(length.max(5)) // 5 = false.toString
+      case (ColumnTypeBoolean, ColumnTypeShort(length)) =>
+        ColumnTypeShort(length.max(5)) // 5 = false.toString
       case (ColumnTypeBoolean, ColumnTypeInt(length)) =>
         ColumnTypeInt(length.max(5)) // 5 = false.toString
       case (ColumnTypeBoolean, ColumnTypeLong(length)) =>
@@ -94,6 +102,8 @@ object ColumnType {
       case (ColumnTypeByte(_), ColumnTypeBoolean) => merge(b, a)
       case (ColumnTypeByte(alength), ColumnTypeByte(blength)) =>
         ColumnTypeByte(alength.max(blength))
+      case (ColumnTypeByte(alength), ColumnTypeShort(blength)) =>
+        ColumnTypeShort(alength.max(blength))
       case (ColumnTypeByte(alength), ColumnTypeInt(blength)) =>
         ColumnTypeInt(alength.max(blength))
       case (ColumnTypeByte(alength), ColumnTypeLong(blength)) =>
@@ -106,9 +116,27 @@ object ColumnType {
         ColumnTypeString(alength.max(blength))
       case (ColumnTypeByte(_), ColumnTypeUnknown) => ColumnTypeUnknown
 
+      // ColumnTypeShort
+      case (ColumnTypeShort(_), ColumnTypeBoolean) => merge(b, a)
+      case (ColumnTypeShort(_), ColumnTypeByte(_)) => merge(b, a)
+      case (ColumnTypeShort(alength), ColumnTypeShort(blength)) =>
+        ColumnTypeShort(alength.max(blength))
+      case (ColumnTypeShort(alength), ColumnTypeInt(blength)) =>
+        ColumnTypeInt(alength.max(blength))
+      case (ColumnTypeShort(alength), ColumnTypeLong(blength)) =>
+        ColumnTypeLong(alength.max(blength))
+      case (ColumnTypeShort(alength), ColumnTypeDouble(blength)) =>
+        ColumnTypeDouble(alength.max(blength))
+      case (ColumnTypeShort(alength), ColumnTypeCharacter(blength)) =>
+        ColumnTypeCharacter(alength.max(blength))
+      case (ColumnTypeShort(alength), ColumnTypeString(blength)) =>
+        ColumnTypeString(alength.max(blength))
+      case (ColumnTypeShort(_), ColumnTypeUnknown) => ColumnTypeUnknown
+
       // ColumnTypeInt
-      case (ColumnTypeInt(_), ColumnTypeBoolean) => merge(b, a)
-      case (ColumnTypeInt(_), ColumnTypeByte(_)) => merge(b, a)
+      case (ColumnTypeInt(_), ColumnTypeBoolean)  => merge(b, a)
+      case (ColumnTypeInt(_), ColumnTypeByte(_))  => merge(b, a)
+      case (ColumnTypeInt(_), ColumnTypeShort(_)) => merge(b, a)
       case (ColumnTypeInt(alength), ColumnTypeInt(blength)) =>
         ColumnTypeInt(alength.max(blength))
       case (ColumnTypeInt(alength), ColumnTypeLong(blength)) =>
@@ -122,9 +150,10 @@ object ColumnType {
       case (ColumnTypeInt(_), ColumnTypeUnknown) => ColumnTypeUnknown
 
       // ColumnTypeLong
-      case (ColumnTypeLong(_), ColumnTypeBoolean) => merge(b, a)
-      case (ColumnTypeLong(_), ColumnTypeByte(_)) => merge(b, a)
-      case (ColumnTypeLong(_), ColumnTypeInt(_))  => merge(b, a)
+      case (ColumnTypeLong(_), ColumnTypeBoolean)  => merge(b, a)
+      case (ColumnTypeLong(_), ColumnTypeByte(_))  => merge(b, a)
+      case (ColumnTypeLong(_), ColumnTypeShort(_)) => merge(b, a)
+      case (ColumnTypeLong(_), ColumnTypeInt(_))   => merge(b, a)
       case (ColumnTypeLong(alength), ColumnTypeLong(blength)) =>
         ColumnTypeLong(alength.max(blength))
       case (ColumnTypeLong(alength), ColumnTypeDouble(blength)) =>
@@ -136,10 +165,11 @@ object ColumnType {
       case (ColumnTypeLong(_), ColumnTypeUnknown) => ColumnTypeUnknown
 
       // ColumnTypeDouble
-      case (ColumnTypeDouble(_), ColumnTypeBoolean) => merge(b, a)
-      case (ColumnTypeDouble(_), ColumnTypeByte(_)) => merge(b, a)
-      case (ColumnTypeDouble(_), ColumnTypeInt(_))  => merge(b, a)
-      case (ColumnTypeDouble(_), ColumnTypeLong(_)) => merge(b, a)
+      case (ColumnTypeDouble(_), ColumnTypeBoolean)  => merge(b, a)
+      case (ColumnTypeDouble(_), ColumnTypeByte(_))  => merge(b, a)
+      case (ColumnTypeDouble(_), ColumnTypeShort(_)) => merge(b, a)
+      case (ColumnTypeDouble(_), ColumnTypeInt(_))   => merge(b, a)
+      case (ColumnTypeDouble(_), ColumnTypeLong(_))  => merge(b, a)
       case (ColumnTypeDouble(alength), ColumnTypeDouble(blength)) =>
         ColumnTypeDouble(alength.max(blength))
       case (ColumnTypeDouble(alength), ColumnTypeString(blength)) =>
@@ -151,6 +181,7 @@ object ColumnType {
       // ColumnTypeCharacter
       case (ColumnTypeCharacter(_), ColumnTypeBoolean)   => merge(b, a)
       case (ColumnTypeCharacter(_), ColumnTypeByte(_))   => merge(b, a)
+      case (ColumnTypeCharacter(_), ColumnTypeShort(_))  => merge(b, a)
       case (ColumnTypeCharacter(_), ColumnTypeInt(_))    => merge(b, a)
       case (ColumnTypeCharacter(_), ColumnTypeLong(_))   => merge(b, a)
       case (ColumnTypeCharacter(_), ColumnTypeDouble(_)) => merge(b, a)
@@ -163,6 +194,7 @@ object ColumnType {
       // ColumnTypeString
       case (ColumnTypeString(_), ColumnTypeBoolean)      => merge(b, a)
       case (ColumnTypeString(_), ColumnTypeByte(_))      => merge(b, a)
+      case (ColumnTypeString(_), ColumnTypeShort(_))     => merge(b, a)
       case (ColumnTypeString(_), ColumnTypeInt(_))       => merge(b, a)
       case (ColumnTypeString(_), ColumnTypeLong(_))      => merge(b, a)
       case (ColumnTypeString(_), ColumnTypeDouble(_))    => merge(b, a)
@@ -174,6 +206,7 @@ object ColumnType {
       // ColumnTypeUnknown
       case (ColumnTypeUnknown, ColumnTypeBoolean)      => merge(b, a)
       case (ColumnTypeUnknown, ColumnTypeByte(_))      => merge(b, a)
+      case (ColumnTypeUnknown, ColumnTypeShort(_))     => merge(b, a)
       case (ColumnTypeUnknown, ColumnTypeInt(_))       => merge(b, a)
       case (ColumnTypeUnknown, ColumnTypeLong(_))      => merge(b, a)
       case (ColumnTypeUnknown, ColumnTypeDouble(_))    => merge(b, a)

--- a/src/main/scala/domain/table/dml/RecordValue.scala
+++ b/src/main/scala/domain/table/dml/RecordValue.scala
@@ -3,6 +3,7 @@ package domain.table.dml
 import domain.table.ddl.column.{
   ColumnType,
   ColumnTypeBoolean,
+  ColumnTypeCharacter,
   ColumnTypeDouble,
   ColumnTypeInt,
   ColumnTypeLong,
@@ -18,12 +19,13 @@ final case class RecordValue(private val value: Map[String, Any])
 
     val valuesForSql = values.map { value =>
       ColumnType.apply(value) match {
-        case ColumnTypeBoolean   => value
-        case ColumnTypeInt(_)    => value
-        case ColumnTypeLong(_)   => value
-        case ColumnTypeDouble(_) => value
-        case ColumnTypeString(_) => s"\"$value\""
-        case ColumnTypeUnknown   => s"\"$value\""
+        case ColumnTypeBoolean      => value
+        case ColumnTypeInt(_)       => value
+        case ColumnTypeLong(_)      => value
+        case ColumnTypeDouble(_)    => value
+        case ColumnTypeCharacter(_) => s"\"$value\""
+        case ColumnTypeString(_)    => s"\"$value\""
+        case ColumnTypeUnknown      => s"\"$value\""
       }
     }
 

--- a/src/main/scala/domain/table/dml/RecordValue.scala
+++ b/src/main/scala/domain/table/dml/RecordValue.scala
@@ -8,6 +8,7 @@ import domain.table.ddl.column.{
   ColumnTypeDouble,
   ColumnTypeInt,
   ColumnTypeLong,
+  ColumnTypeShort,
   ColumnTypeString,
   ColumnTypeUnknown
 }
@@ -22,6 +23,7 @@ final case class RecordValue(private val value: Map[String, Any])
       ColumnType.apply(value) match {
         case ColumnTypeBoolean      => value
         case ColumnTypeByte(_)      => value
+        case ColumnTypeShort(_)     => value
         case ColumnTypeInt(_)       => value
         case ColumnTypeLong(_)      => value
         case ColumnTypeDouble(_)    => value

--- a/src/main/scala/domain/table/dml/RecordValue.scala
+++ b/src/main/scala/domain/table/dml/RecordValue.scala
@@ -6,6 +6,7 @@ import domain.table.ddl.column.{
   ColumnTypeByte,
   ColumnTypeCharacter,
   ColumnTypeDouble,
+  ColumnTypeFloat,
   ColumnTypeInt,
   ColumnTypeLong,
   ColumnTypeShort,
@@ -26,6 +27,7 @@ final case class RecordValue(private val value: Map[String, Any])
         case ColumnTypeShort(_)     => value
         case ColumnTypeInt(_)       => value
         case ColumnTypeLong(_)      => value
+        case ColumnTypeFloat(_)     => value
         case ColumnTypeDouble(_)    => value
         case ColumnTypeCharacter(_) => s"\"$value\""
         case ColumnTypeString(_)    => s"\"$value\""

--- a/src/main/scala/domain/table/dml/RecordValue.scala
+++ b/src/main/scala/domain/table/dml/RecordValue.scala
@@ -3,6 +3,7 @@ package domain.table.dml
 import domain.table.ddl.column.{
   ColumnType,
   ColumnTypeBoolean,
+  ColumnTypeByte,
   ColumnTypeCharacter,
   ColumnTypeDouble,
   ColumnTypeInt,
@@ -20,6 +21,7 @@ final case class RecordValue(private val value: Map[String, Any])
     val valuesForSql = values.map { value =>
       ColumnType.apply(value) match {
         case ColumnTypeBoolean      => value
+        case ColumnTypeByte(_)      => value
         case ColumnTypeInt(_)       => value
         case ColumnTypeLong(_)      => value
         case ColumnTypeDouble(_)    => value

--- a/src/main/scala/domain/table/dml/RecordValue.scala
+++ b/src/main/scala/domain/table/dml/RecordValue.scala
@@ -11,6 +11,7 @@ import domain.table.ddl.column.{
   ColumnTypeLong,
   ColumnTypeShort,
   ColumnTypeString,
+  ColumnTypeUUID,
   ColumnTypeUnknown
 }
 
@@ -29,6 +30,7 @@ final case class RecordValue(private val value: Map[String, Any])
         case ColumnTypeLong(_)      => value
         case ColumnTypeFloat(_)     => value
         case ColumnTypeDouble(_)    => value
+        case ColumnTypeUUID         => s"\"$value\""
         case ColumnTypeCharacter(_) => s"\"$value\""
         case ColumnTypeString(_)    => s"\"$value\""
         case ColumnTypeUnknown      => s"\"$value\""

--- a/src/test/scala/domain/table/ddl/column/ColumnTypeSpec.scala
+++ b/src/test/scala/domain/table/ddl/column/ColumnTypeSpec.scala
@@ -11,6 +11,7 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ColumnType.apply(1.toShort) shouldBe ColumnTypeShort(ColumnLength(1))
       ColumnType.apply(1) shouldBe ColumnTypeInt(ColumnLength(1))
       ColumnType.apply(1.toLong) shouldBe ColumnTypeLong(ColumnLength(1))
+      ColumnType.apply(1.1.toFloat) shouldBe ColumnTypeFloat(ColumnLength(3))
       ColumnType.apply(1.1) shouldBe ColumnTypeDouble(ColumnLength(3))
       ColumnType.apply('a') shouldBe ColumnTypeCharacter(ColumnLength(1))
       ColumnType.apply("string") shouldBe ColumnTypeString(ColumnLength(6))
@@ -29,6 +30,8 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       val columnTypeIntBig = ColumnTypeInt(ColumnLength(2))
       val columnTypeLongSmall = ColumnTypeLong(ColumnLength(1))
       val columnTypeLongBig = ColumnTypeLong(ColumnLength(2))
+      val columnTypeFloatSmall = ColumnTypeFloat(ColumnLength(1))
+      val columnTypeFloatBig = ColumnTypeFloat(ColumnLength(2))
       val columnTypeDoubleSmall = ColumnTypeDouble(ColumnLength(1))
       val columnTypeDoubleBig = ColumnTypeDouble(ColumnLength(2))
       val columnTypeCharacterSmall = ColumnTypeCharacter(ColumnLength(1))
@@ -58,6 +61,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeBoolean,
         columnTypeLongBig
       ) shouldBe ColumnTypeLong(ColumnLength(5))
+      ColumnType.merge(
+        columnTypeBoolean,
+        columnTypeFloatBig
+      ) shouldBe ColumnTypeFloat(ColumnLength(5))
       ColumnType.merge(
         columnTypeBoolean,
         columnTypeDoubleBig
@@ -98,6 +105,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeLongBig
       ColumnType.merge(
         columnTypeByteSmall,
+        columnTypeFloatBig
+      ) shouldBe columnTypeFloatBig
+      ColumnType.merge(
+        columnTypeByteSmall,
         columnTypeDoubleBig
       ) shouldBe columnTypeDoubleBig
       ColumnType.merge(
@@ -134,6 +145,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeShortSmall,
         columnTypeLongBig
       ) shouldBe columnTypeLongBig
+      ColumnType.merge(
+        columnTypeShortSmall,
+        columnTypeFloatBig
+      ) shouldBe columnTypeFloatBig
       ColumnType.merge(
         columnTypeShortSmall,
         columnTypeDoubleBig
@@ -174,6 +189,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeLongBig
       ColumnType.merge(
         columnTypeIntSmall,
+        columnTypeFloatBig
+      ) shouldBe columnTypeFloatBig
+      ColumnType.merge(
+        columnTypeIntSmall,
         columnTypeDoubleBig
       ) shouldBe columnTypeDoubleBig
       ColumnType.merge(
@@ -197,19 +216,23 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ColumnType.merge(
         columnTypeLongSmall,
         columnTypeByteBig
-      ) shouldBe ColumnTypeLong(ColumnLength(2))
+      ) shouldBe columnTypeLongBig
       ColumnType.merge(
         columnTypeLongSmall,
         columnTypeShortBig
-      ) shouldBe ColumnTypeLong(ColumnLength(2))
+      ) shouldBe columnTypeLongBig
       ColumnType.merge(
         columnTypeLongSmall,
         columnTypeIntBig
-      ) shouldBe ColumnTypeLong(ColumnLength(2))
+      ) shouldBe columnTypeLongBig
       ColumnType.merge(
         columnTypeLongSmall,
         columnTypeLongBig
       ) shouldBe columnTypeLongBig
+      ColumnType.merge(
+        columnTypeLongSmall,
+        columnTypeFloatBig
+      ) shouldBe columnTypeFloatBig
       ColumnType.merge(
         columnTypeLongSmall,
         columnTypeDoubleBig
@@ -227,6 +250,48 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeUnknown
       ) shouldBe columnTypeUnknown
 
+      // ColumnTypeFloat
+      ColumnType.merge(
+        columnTypeFloatSmall,
+        columnTypeBoolean
+      ) shouldBe ColumnTypeFloat(ColumnLength(5))
+      ColumnType.merge(
+        columnTypeFloatSmall,
+        columnTypeByteBig
+      ) shouldBe columnTypeFloatBig
+      ColumnType.merge(
+        columnTypeFloatSmall,
+        columnTypeShortBig
+      ) shouldBe columnTypeFloatBig
+      ColumnType.merge(
+        columnTypeFloatSmall,
+        columnTypeIntBig
+      ) shouldBe columnTypeFloatBig
+      ColumnType.merge(
+        columnTypeFloatSmall,
+        columnTypeLongBig
+      ) shouldBe columnTypeFloatBig
+      ColumnType.merge(
+        columnTypeFloatSmall,
+        columnTypeFloatBig
+      ) shouldBe columnTypeFloatBig
+      ColumnType.merge(
+        columnTypeFloatSmall,
+        columnTypeDoubleBig
+      ) shouldBe columnTypeDoubleBig
+      ColumnType.merge(
+        columnTypeFloatSmall,
+        columnTypeCharacterBig
+      ) shouldBe columnTypeCharacterBig
+      ColumnType.merge(
+        columnTypeFloatSmall,
+        columnTypeStringBig
+      ) shouldBe columnTypeStringBig
+      ColumnType.merge(
+        columnTypeFloatSmall,
+        columnTypeUnknown
+      ) shouldBe columnTypeUnknown
+
       // ColumnTypeDouble
       ColumnType.merge(
         columnTypeDoubleSmall,
@@ -235,19 +300,23 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ColumnType.merge(
         columnTypeDoubleSmall,
         columnTypeByteBig
-      ) shouldBe ColumnTypeDouble(ColumnLength(2))
+      ) shouldBe columnTypeDoubleBig
       ColumnType.merge(
         columnTypeDoubleSmall,
         columnTypeShortBig
-      ) shouldBe ColumnTypeDouble(ColumnLength(2))
+      ) shouldBe columnTypeDoubleBig
       ColumnType.merge(
         columnTypeDoubleSmall,
         columnTypeIntBig
-      ) shouldBe ColumnTypeDouble(ColumnLength(2))
+      ) shouldBe columnTypeDoubleBig
       ColumnType.merge(
         columnTypeDoubleSmall,
         columnTypeLongBig
-      ) shouldBe ColumnTypeDouble(ColumnLength(2))
+      ) shouldBe columnTypeDoubleBig
+      ColumnType.merge(
+        columnTypeDoubleSmall,
+        columnTypeFloatBig
+      ) shouldBe columnTypeDoubleBig
       ColumnType.merge(
         columnTypeDoubleSmall,
         columnTypeDoubleBig
@@ -273,23 +342,27 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ColumnType.merge(
         columnTypeCharacterSmall,
         columnTypeByteBig
-      ) shouldBe ColumnTypeCharacter(ColumnLength(2))
+      ) shouldBe columnTypeCharacterBig
       ColumnType.merge(
         columnTypeCharacterSmall,
         columnTypeShortBig
-      ) shouldBe ColumnTypeCharacter(ColumnLength(2))
+      ) shouldBe columnTypeCharacterBig
       ColumnType.merge(
         columnTypeCharacterSmall,
         columnTypeIntBig
-      ) shouldBe ColumnTypeCharacter(ColumnLength(2))
+      ) shouldBe columnTypeCharacterBig
       ColumnType.merge(
         columnTypeCharacterSmall,
         columnTypeLongBig
-      ) shouldBe ColumnTypeCharacter(ColumnLength(2))
+      ) shouldBe columnTypeCharacterBig
+      ColumnType.merge(
+        columnTypeCharacterSmall,
+        columnTypeFloatBig
+      ) shouldBe columnTypeCharacterBig
       ColumnType.merge(
         columnTypeCharacterSmall,
         columnTypeDoubleBig
-      ) shouldBe ColumnTypeCharacter(ColumnLength(2))
+      ) shouldBe columnTypeCharacterBig
       ColumnType.merge(
         columnTypeCharacterSmall,
         columnTypeCharacterBig
@@ -311,23 +384,27 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ColumnType.merge(
         columnTypeStringSmall,
         columnTypeByteBig
-      ) shouldBe ColumnTypeString(ColumnLength(2))
+      ) shouldBe columnTypeStringBig
       ColumnType.merge(
         columnTypeStringSmall,
         columnTypeShortBig
-      ) shouldBe ColumnTypeString(ColumnLength(2))
+      ) shouldBe columnTypeStringBig
       ColumnType.merge(
         columnTypeStringSmall,
         columnTypeIntBig
-      ) shouldBe ColumnTypeString(ColumnLength(2))
+      ) shouldBe columnTypeStringBig
       ColumnType.merge(
         columnTypeStringSmall,
         columnTypeLongBig
-      ) shouldBe ColumnTypeString(ColumnLength(2))
+      ) shouldBe columnTypeStringBig
+      ColumnType.merge(
+        columnTypeStringSmall,
+        columnTypeFloatBig
+      ) shouldBe columnTypeStringBig
       ColumnType.merge(
         columnTypeStringSmall,
         columnTypeDoubleBig
-      ) shouldBe ColumnTypeString(ColumnLength(2))
+      ) shouldBe columnTypeStringBig
       ColumnType.merge(
         columnTypeStringSmall,
         columnTypeCharacterBig
@@ -364,6 +441,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeUnknown
       ColumnType.merge(
         columnTypeUnknown,
+        columnTypeFloatBig
+      ) shouldBe columnTypeUnknown
+      ColumnType.merge(
+        columnTypeUnknown,
         columnTypeDoubleBig
       ) shouldBe columnTypeUnknown
       ColumnType.merge(
@@ -388,6 +469,7 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ColumnType.apply(1.toShort).toSqlSentence shouldBe "SMALLINT(1)"
       ColumnType.apply(1).toSqlSentence shouldBe "INT(1)"
       ColumnType.apply(1.toLong).toSqlSentence shouldBe "INT(1)"
+      ColumnType.apply(1.1.toFloat).toSqlSentence shouldBe "FLOAT"
       ColumnType.apply(1.1).toSqlSentence shouldBe "DOUBLE"
       ColumnType.apply('a').toSqlSentence shouldBe "CHAR(1)"
       ColumnType.apply(Seq.empty).toSqlSentence shouldBe "TEXT"

--- a/src/test/scala/domain/table/ddl/column/ColumnTypeSpec.scala
+++ b/src/test/scala/domain/table/ddl/column/ColumnTypeSpec.scala
@@ -1,15 +1,5 @@
 package domain.table.ddl.column
 
-import domain.table.ddl.column.{
-  ColumnLength,
-  ColumnType,
-  ColumnTypeBoolean,
-  ColumnTypeDouble,
-  ColumnTypeInt,
-  ColumnTypeLong,
-  ColumnTypeString,
-  ColumnTypeUnknown
-}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -17,10 +7,11 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
   describe("apply") {
     it("success") {
       ColumnType.apply(false) shouldBe ColumnTypeBoolean
-      ColumnType.apply("string") shouldBe ColumnTypeString(ColumnLength(6))
       ColumnType.apply(1) shouldBe ColumnTypeInt(ColumnLength(1))
       ColumnType.apply(1.toLong) shouldBe ColumnTypeLong(ColumnLength(1))
       ColumnType.apply(1.1) shouldBe ColumnTypeDouble(ColumnLength(3))
+      ColumnType.apply('a') shouldBe ColumnTypeCharacter(ColumnLength(1))
+      ColumnType.apply("string") shouldBe ColumnTypeString(ColumnLength(6))
       ColumnType.apply(Seq.empty) shouldBe ColumnTypeUnknown
     }
   }
@@ -34,6 +25,8 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       val columnTypeLongBig = ColumnTypeLong(ColumnLength(2))
       val columnTypeDoubleSmall = ColumnTypeDouble(ColumnLength(1))
       val columnTypeDoubleBig = ColumnTypeDouble(ColumnLength(2))
+      val columnTypeCharacterSmall = ColumnTypeCharacter(ColumnLength(1))
+      val columnTypeCharacterBig = ColumnTypeCharacter(ColumnLength(2))
       val columnTypeStringSmall = ColumnTypeString(ColumnLength(1))
       val columnTypeStringBig = ColumnTypeString(ColumnLength(2))
       val columnTypeUnknown = ColumnTypeUnknown
@@ -55,6 +48,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeBoolean,
         columnTypeDoubleBig
       ) shouldBe ColumnTypeDouble(ColumnLength(5))
+      ColumnType.merge(
+        columnTypeBoolean,
+        columnTypeCharacterBig
+      ) shouldBe ColumnTypeCharacter(ColumnLength(5))
       ColumnType.merge(
         columnTypeBoolean,
         columnTypeStringBig
@@ -83,6 +80,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeDoubleBig
       ColumnType.merge(
         columnTypeIntSmall,
+        columnTypeCharacterBig
+      ) shouldBe columnTypeCharacterBig
+      ColumnType.merge(
+        columnTypeIntSmall,
         columnTypeStringBig
       ) shouldBe columnTypeStringBig
       ColumnType.merge(
@@ -107,6 +108,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeLongSmall,
         columnTypeDoubleBig
       ) shouldBe columnTypeDoubleBig
+      ColumnType.merge(
+        columnTypeLongSmall,
+        columnTypeCharacterBig
+      ) shouldBe columnTypeCharacterBig
       ColumnType.merge(
         columnTypeLongSmall,
         columnTypeStringBig
@@ -135,10 +140,44 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeDoubleBig
       ColumnType.merge(
         columnTypeDoubleSmall,
+        columnTypeCharacterBig
+      ) shouldBe columnTypeCharacterBig
+      ColumnType.merge(
+        columnTypeDoubleSmall,
         columnTypeStringBig
       ) shouldBe columnTypeStringBig
       ColumnType.merge(
         columnTypeDoubleSmall,
+        columnTypeUnknown
+      ) shouldBe columnTypeUnknown
+
+      // ColumnTypeCharacter
+      ColumnType.merge(
+        columnTypeCharacterSmall,
+        columnTypeBoolean
+      ) shouldBe ColumnTypeCharacter(ColumnLength(5))
+      ColumnType.merge(
+        columnTypeCharacterSmall,
+        columnTypeIntBig
+      ) shouldBe ColumnTypeCharacter(ColumnLength(2))
+      ColumnType.merge(
+        columnTypeCharacterSmall,
+        columnTypeLongBig
+      ) shouldBe ColumnTypeCharacter(ColumnLength(2))
+      ColumnType.merge(
+        columnTypeCharacterSmall,
+        columnTypeDoubleBig
+      ) shouldBe ColumnTypeCharacter(ColumnLength(2))
+      ColumnType.merge(
+        columnTypeCharacterSmall,
+        columnTypeCharacterBig
+      ) shouldBe columnTypeCharacterBig
+      ColumnType.merge(
+        columnTypeCharacterSmall,
+        columnTypeStringBig
+      ) shouldBe columnTypeStringBig
+      ColumnType.merge(
+        columnTypeCharacterSmall,
         columnTypeUnknown
       ) shouldBe columnTypeUnknown
 
@@ -159,6 +198,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeStringSmall,
         columnTypeDoubleBig
       ) shouldBe ColumnTypeString(ColumnLength(2))
+      ColumnType.merge(
+        columnTypeStringSmall,
+        columnTypeCharacterBig
+      ) shouldBe columnTypeStringBig
       ColumnType.merge(
         columnTypeStringSmall,
         columnTypeStringBig
@@ -187,6 +230,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeUnknown
       ColumnType.merge(
         columnTypeUnknown,
+        columnTypeCharacterBig
+      ) shouldBe columnTypeUnknown
+      ColumnType.merge(
+        columnTypeUnknown,
         columnTypeStringBig
       ) shouldBe columnTypeUnknown
       ColumnType.merge(
@@ -199,10 +246,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
   describe("toSqlSentence") {
     it("success") {
       ColumnType.apply(false).toSqlSentence shouldBe "BOOLEAN"
-      ColumnType.apply("string").toSqlSentence shouldBe "VARCHAR(6)"
       ColumnType.apply(1).toSqlSentence shouldBe "INT(1)"
       ColumnType.apply(1.toLong).toSqlSentence shouldBe "INT(1)"
       ColumnType.apply(1.1).toSqlSentence shouldBe "DOUBLE"
+      ColumnType.apply('a').toSqlSentence shouldBe "CHAR(1)"
       ColumnType.apply(Seq.empty).toSqlSentence shouldBe "TEXT"
     }
   }

--- a/src/test/scala/domain/table/ddl/column/ColumnTypeSpec.scala
+++ b/src/test/scala/domain/table/ddl/column/ColumnTypeSpec.scala
@@ -7,6 +7,7 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
   describe("apply") {
     it("success") {
       ColumnType.apply(false) shouldBe ColumnTypeBoolean
+      ColumnType.apply(1.toByte) shouldBe ColumnTypeByte(ColumnLength(1))
       ColumnType.apply(1) shouldBe ColumnTypeInt(ColumnLength(1))
       ColumnType.apply(1.toLong) shouldBe ColumnTypeLong(ColumnLength(1))
       ColumnType.apply(1.1) shouldBe ColumnTypeDouble(ColumnLength(3))
@@ -19,6 +20,8 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
   describe("merge") {
     it("success") {
       val columnTypeBoolean = ColumnTypeBoolean
+      val columnTypeByteSmall = ColumnTypeByte(ColumnLength(1))
+      val columnTypeByteBig = ColumnTypeByte(ColumnLength(2))
       val columnTypeIntSmall = ColumnTypeInt(ColumnLength(1))
       val columnTypeIntBig = ColumnTypeInt(ColumnLength(2))
       val columnTypeLongSmall = ColumnTypeLong(ColumnLength(1))
@@ -36,6 +39,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeBoolean,
         columnTypeBoolean
       ) shouldBe columnTypeBoolean
+      ColumnType.merge(
+        columnTypeBoolean,
+        columnTypeByteBig
+      ) shouldBe ColumnTypeByte(ColumnLength(5))
       ColumnType.merge(
         columnTypeBoolean,
         columnTypeIntBig
@@ -61,11 +68,49 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeUnknown
       ) shouldBe columnTypeUnknown
 
+      // ColumnTypeByte
+      ColumnType.merge(
+        columnTypeByteSmall,
+        columnTypeBoolean
+      ) shouldBe ColumnTypeByte(ColumnLength(5))
+      ColumnType.merge(
+        columnTypeByteSmall,
+        columnTypeByteBig
+      ) shouldBe columnTypeByteBig
+      ColumnType.merge(
+        columnTypeByteSmall,
+        columnTypeIntBig
+      ) shouldBe columnTypeIntBig
+      ColumnType.merge(
+        columnTypeByteSmall,
+        columnTypeLongBig
+      ) shouldBe columnTypeLongBig
+      ColumnType.merge(
+        columnTypeByteSmall,
+        columnTypeDoubleBig
+      ) shouldBe columnTypeDoubleBig
+      ColumnType.merge(
+        columnTypeByteSmall,
+        columnTypeCharacterBig
+      ) shouldBe columnTypeCharacterBig
+      ColumnType.merge(
+        columnTypeByteSmall,
+        columnTypeStringBig
+      ) shouldBe columnTypeStringBig
+      ColumnType.merge(
+        columnTypeByteSmall,
+        columnTypeUnknown
+      ) shouldBe columnTypeUnknown
+
       // ColumnTypeInt
       ColumnType.merge(
         columnTypeIntSmall,
         columnTypeBoolean
       ) shouldBe ColumnTypeInt(ColumnLength(5))
+      ColumnType.merge(
+        columnTypeIntSmall,
+        columnTypeByteBig
+      ) shouldBe columnTypeIntBig
       ColumnType.merge(
         columnTypeIntSmall,
         columnTypeIntBig
@@ -98,6 +143,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe ColumnTypeLong(ColumnLength(5))
       ColumnType.merge(
         columnTypeLongSmall,
+        columnTypeByteBig
+      ) shouldBe ColumnTypeLong(ColumnLength(2))
+      ColumnType.merge(
+        columnTypeLongSmall,
         columnTypeIntBig
       ) shouldBe ColumnTypeLong(ColumnLength(2))
       ColumnType.merge(
@@ -126,6 +175,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeDoubleSmall,
         columnTypeBoolean
       ) shouldBe ColumnTypeDouble(ColumnLength(5))
+      ColumnType.merge(
+        columnTypeDoubleSmall,
+        columnTypeByteBig
+      ) shouldBe ColumnTypeDouble(ColumnLength(2))
       ColumnType.merge(
         columnTypeDoubleSmall,
         columnTypeIntBig
@@ -162,6 +215,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe ColumnTypeCharacter(ColumnLength(2))
       ColumnType.merge(
         columnTypeCharacterSmall,
+        columnTypeByteBig
+      ) shouldBe ColumnTypeCharacter(ColumnLength(2))
+      ColumnType.merge(
+        columnTypeCharacterSmall,
         columnTypeLongBig
       ) shouldBe ColumnTypeCharacter(ColumnLength(2))
       ColumnType.merge(
@@ -192,6 +249,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe ColumnTypeString(ColumnLength(2))
       ColumnType.merge(
         columnTypeStringSmall,
+        columnTypeByteBig
+      ) shouldBe ColumnTypeString(ColumnLength(2))
+      ColumnType.merge(
+        columnTypeStringSmall,
         columnTypeLongBig
       ) shouldBe ColumnTypeString(ColumnLength(2))
       ColumnType.merge(
@@ -215,6 +276,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ColumnType.merge(
         columnTypeUnknown,
         columnTypeBoolean
+      ) shouldBe columnTypeUnknown
+      ColumnType.merge(
+        columnTypeUnknown,
+        columnTypeByteBig
       ) shouldBe columnTypeUnknown
       ColumnType.merge(
         columnTypeUnknown,
@@ -246,6 +311,7 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
   describe("toSqlSentence") {
     it("success") {
       ColumnType.apply(false).toSqlSentence shouldBe "BOOLEAN"
+      ColumnType.apply(1.toByte).toSqlSentence shouldBe "TINYINT(1)"
       ColumnType.apply(1).toSqlSentence shouldBe "INT(1)"
       ColumnType.apply(1.toLong).toSqlSentence shouldBe "INT(1)"
       ColumnType.apply(1.1).toSqlSentence shouldBe "DOUBLE"

--- a/src/test/scala/domain/table/ddl/column/ColumnTypeSpec.scala
+++ b/src/test/scala/domain/table/ddl/column/ColumnTypeSpec.scala
@@ -3,6 +3,8 @@ package domain.table.ddl.column
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.util.UUID
+
 class ColumnTypeSpec extends AnyFunSpec with Matchers {
   describe("apply") {
     it("success") {
@@ -13,6 +15,7 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ColumnType.apply(1.toLong) shouldBe ColumnTypeLong(ColumnLength(1))
       ColumnType.apply(1.1.toFloat) shouldBe ColumnTypeFloat(ColumnLength(3))
       ColumnType.apply(1.1) shouldBe ColumnTypeDouble(ColumnLength(3))
+      ColumnType.apply(UUID.randomUUID()) shouldBe ColumnTypeUUID
       ColumnType.apply('a') shouldBe ColumnTypeCharacter(ColumnLength(1))
       ColumnType.apply("string") shouldBe ColumnTypeString(ColumnLength(6))
       ColumnType.apply(Seq.empty) shouldBe ColumnTypeUnknown
@@ -34,6 +37,7 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       val columnTypeFloatBig = ColumnTypeFloat(ColumnLength(2))
       val columnTypeDoubleSmall = ColumnTypeDouble(ColumnLength(1))
       val columnTypeDoubleBig = ColumnTypeDouble(ColumnLength(2))
+      val columnTypeUUID = ColumnTypeUUID
       val columnTypeCharacterSmall = ColumnTypeCharacter(ColumnLength(1))
       val columnTypeCharacterBig = ColumnTypeCharacter(ColumnLength(2))
       val columnTypeStringSmall = ColumnTypeString(ColumnLength(1))
@@ -69,6 +73,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeBoolean,
         columnTypeDoubleBig
       ) shouldBe ColumnTypeDouble(ColumnLength(5))
+      ColumnType.merge(
+        columnTypeBoolean,
+        columnTypeUUID
+      ) shouldBe ColumnTypeCharacter(ColumnLength(36))
       ColumnType.merge(
         columnTypeBoolean,
         columnTypeCharacterBig
@@ -113,6 +121,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeDoubleBig
       ColumnType.merge(
         columnTypeByteSmall,
+        columnTypeUUID
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        columnTypeByteSmall,
         columnTypeCharacterBig
       ) shouldBe columnTypeCharacterBig
       ColumnType.merge(
@@ -155,6 +167,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeDoubleBig
       ColumnType.merge(
         columnTypeShortSmall,
+        columnTypeUUID
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        columnTypeShortSmall,
         columnTypeCharacterBig
       ) shouldBe columnTypeCharacterBig
       ColumnType.merge(
@@ -195,6 +211,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeIntSmall,
         columnTypeDoubleBig
       ) shouldBe columnTypeDoubleBig
+      ColumnType.merge(
+        columnTypeIntSmall,
+        columnTypeUUID
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
       ColumnType.merge(
         columnTypeIntSmall,
         columnTypeCharacterBig
@@ -243,6 +263,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeCharacterBig
       ColumnType.merge(
         columnTypeLongSmall,
+        columnTypeUUID
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        columnTypeLongSmall,
         columnTypeStringBig
       ) shouldBe columnTypeStringBig
       ColumnType.merge(
@@ -279,6 +303,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeFloatSmall,
         columnTypeDoubleBig
       ) shouldBe columnTypeDoubleBig
+      ColumnType.merge(
+        columnTypeFloatSmall,
+        columnTypeUUID
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
       ColumnType.merge(
         columnTypeFloatSmall,
         columnTypeCharacterBig
@@ -323,6 +351,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeDoubleBig
       ColumnType.merge(
         columnTypeDoubleSmall,
+        columnTypeUUID
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        columnTypeDoubleSmall,
         columnTypeCharacterBig
       ) shouldBe columnTypeCharacterBig
       ColumnType.merge(
@@ -331,6 +363,52 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeStringBig
       ColumnType.merge(
         columnTypeDoubleSmall,
+        columnTypeUnknown
+      ) shouldBe columnTypeUnknown
+
+      // ColumnTypeUUID
+      ColumnType.merge(
+        ColumnTypeUUID,
+        columnTypeBoolean
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        ColumnTypeUUID,
+        columnTypeByteBig
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        ColumnTypeUUID,
+        columnTypeShortBig
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        ColumnTypeUUID,
+        columnTypeIntBig
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        ColumnTypeUUID,
+        columnTypeLongBig
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        ColumnTypeUUID,
+        columnTypeFloatBig
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        ColumnTypeUUID,
+        columnTypeDoubleBig
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        ColumnTypeUUID,
+        ColumnTypeUUID
+      ) shouldBe ColumnTypeUUID
+      ColumnType.merge(
+        ColumnTypeUUID,
+        columnTypeCharacterBig
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
+      ColumnType.merge(
+        ColumnTypeUUID,
+        columnTypeStringBig
+      ) shouldBe ColumnTypeString(ColumnTypeUUID.length)
+      ColumnType.merge(
+        ColumnTypeUUID,
         columnTypeUnknown
       ) shouldBe columnTypeUnknown
 
@@ -363,6 +441,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeCharacterSmall,
         columnTypeDoubleBig
       ) shouldBe columnTypeCharacterBig
+      ColumnType.merge(
+        columnTypeCharacterSmall,
+        columnTypeUUID
+      ) shouldBe ColumnTypeCharacter(ColumnTypeUUID.length)
       ColumnType.merge(
         columnTypeCharacterSmall,
         columnTypeCharacterBig
@@ -407,6 +489,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeStringBig
       ColumnType.merge(
         columnTypeStringSmall,
+        columnTypeUUID
+      ) shouldBe ColumnTypeString(ColumnTypeUUID.length)
+      ColumnType.merge(
+        columnTypeStringSmall,
         columnTypeCharacterBig
       ) shouldBe columnTypeStringBig
       ColumnType.merge(
@@ -449,6 +535,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeUnknown
       ColumnType.merge(
         columnTypeUnknown,
+        columnTypeUUID
+      ) shouldBe columnTypeUnknown
+      ColumnType.merge(
+        columnTypeUnknown,
         columnTypeCharacterBig
       ) shouldBe columnTypeUnknown
       ColumnType.merge(
@@ -471,6 +561,7 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ColumnType.apply(1.toLong).toSqlSentence shouldBe "INT(1)"
       ColumnType.apply(1.1.toFloat).toSqlSentence shouldBe "FLOAT"
       ColumnType.apply(1.1).toSqlSentence shouldBe "DOUBLE"
+      ColumnType.apply(UUID.randomUUID()).toSqlSentence shouldBe "CHAR(36)"
       ColumnType.apply('a').toSqlSentence shouldBe "CHAR(1)"
       ColumnType.apply(Seq.empty).toSqlSentence shouldBe "TEXT"
     }

--- a/src/test/scala/domain/table/ddl/column/ColumnTypeSpec.scala
+++ b/src/test/scala/domain/table/ddl/column/ColumnTypeSpec.scala
@@ -8,6 +8,7 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
     it("success") {
       ColumnType.apply(false) shouldBe ColumnTypeBoolean
       ColumnType.apply(1.toByte) shouldBe ColumnTypeByte(ColumnLength(1))
+      ColumnType.apply(1.toShort) shouldBe ColumnTypeShort(ColumnLength(1))
       ColumnType.apply(1) shouldBe ColumnTypeInt(ColumnLength(1))
       ColumnType.apply(1.toLong) shouldBe ColumnTypeLong(ColumnLength(1))
       ColumnType.apply(1.1) shouldBe ColumnTypeDouble(ColumnLength(3))
@@ -22,6 +23,8 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       val columnTypeBoolean = ColumnTypeBoolean
       val columnTypeByteSmall = ColumnTypeByte(ColumnLength(1))
       val columnTypeByteBig = ColumnTypeByte(ColumnLength(2))
+      val columnTypeShortSmall = ColumnTypeShort(ColumnLength(1))
+      val columnTypeShortBig = ColumnTypeShort(ColumnLength(2))
       val columnTypeIntSmall = ColumnTypeInt(ColumnLength(1))
       val columnTypeIntBig = ColumnTypeInt(ColumnLength(2))
       val columnTypeLongSmall = ColumnTypeLong(ColumnLength(1))
@@ -43,6 +46,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeBoolean,
         columnTypeByteBig
       ) shouldBe ColumnTypeByte(ColumnLength(5))
+      ColumnType.merge(
+        columnTypeBoolean,
+        columnTypeShortBig
+      ) shouldBe ColumnTypeShort(ColumnLength(5))
       ColumnType.merge(
         columnTypeBoolean,
         columnTypeIntBig
@@ -79,6 +86,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeByteBig
       ColumnType.merge(
         columnTypeByteSmall,
+        columnTypeShortBig
+      ) shouldBe columnTypeShortBig
+      ColumnType.merge(
+        columnTypeByteSmall,
         columnTypeIntBig
       ) shouldBe columnTypeIntBig
       ColumnType.merge(
@@ -102,6 +113,44 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
         columnTypeUnknown
       ) shouldBe columnTypeUnknown
 
+      // ColumnTypeShort
+      ColumnType.merge(
+        columnTypeShortSmall,
+        columnTypeBoolean
+      ) shouldBe ColumnTypeShort(ColumnLength(5))
+      ColumnType.merge(
+        columnTypeShortSmall,
+        columnTypeByteBig
+      ) shouldBe columnTypeShortBig
+      ColumnType.merge(
+        columnTypeShortSmall,
+        columnTypeShortBig
+      ) shouldBe columnTypeShortBig
+      ColumnType.merge(
+        columnTypeShortSmall,
+        columnTypeIntBig
+      ) shouldBe columnTypeIntBig
+      ColumnType.merge(
+        columnTypeShortSmall,
+        columnTypeLongBig
+      ) shouldBe columnTypeLongBig
+      ColumnType.merge(
+        columnTypeShortSmall,
+        columnTypeDoubleBig
+      ) shouldBe columnTypeDoubleBig
+      ColumnType.merge(
+        columnTypeShortSmall,
+        columnTypeCharacterBig
+      ) shouldBe columnTypeCharacterBig
+      ColumnType.merge(
+        columnTypeShortSmall,
+        columnTypeStringBig
+      ) shouldBe columnTypeStringBig
+      ColumnType.merge(
+        columnTypeShortSmall,
+        columnTypeUnknown
+      ) shouldBe columnTypeUnknown
+
       // ColumnTypeInt
       ColumnType.merge(
         columnTypeIntSmall,
@@ -110,6 +159,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ColumnType.merge(
         columnTypeIntSmall,
         columnTypeByteBig
+      ) shouldBe columnTypeIntBig
+      ColumnType.merge(
+        columnTypeIntSmall,
+        columnTypeShortBig
       ) shouldBe columnTypeIntBig
       ColumnType.merge(
         columnTypeIntSmall,
@@ -147,6 +200,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe ColumnTypeLong(ColumnLength(2))
       ColumnType.merge(
         columnTypeLongSmall,
+        columnTypeShortBig
+      ) shouldBe ColumnTypeLong(ColumnLength(2))
+      ColumnType.merge(
+        columnTypeLongSmall,
         columnTypeIntBig
       ) shouldBe ColumnTypeLong(ColumnLength(2))
       ColumnType.merge(
@@ -181,6 +238,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe ColumnTypeDouble(ColumnLength(2))
       ColumnType.merge(
         columnTypeDoubleSmall,
+        columnTypeShortBig
+      ) shouldBe ColumnTypeDouble(ColumnLength(2))
+      ColumnType.merge(
+        columnTypeDoubleSmall,
         columnTypeIntBig
       ) shouldBe ColumnTypeDouble(ColumnLength(2))
       ColumnType.merge(
@@ -211,11 +272,15 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe ColumnTypeCharacter(ColumnLength(5))
       ColumnType.merge(
         columnTypeCharacterSmall,
-        columnTypeIntBig
+        columnTypeByteBig
       ) shouldBe ColumnTypeCharacter(ColumnLength(2))
       ColumnType.merge(
         columnTypeCharacterSmall,
-        columnTypeByteBig
+        columnTypeShortBig
+      ) shouldBe ColumnTypeCharacter(ColumnLength(2))
+      ColumnType.merge(
+        columnTypeCharacterSmall,
+        columnTypeIntBig
       ) shouldBe ColumnTypeCharacter(ColumnLength(2))
       ColumnType.merge(
         columnTypeCharacterSmall,
@@ -245,11 +310,15 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe ColumnTypeString(ColumnLength(5))
       ColumnType.merge(
         columnTypeStringSmall,
-        columnTypeIntBig
+        columnTypeByteBig
       ) shouldBe ColumnTypeString(ColumnLength(2))
       ColumnType.merge(
         columnTypeStringSmall,
-        columnTypeByteBig
+        columnTypeShortBig
+      ) shouldBe ColumnTypeString(ColumnLength(2))
+      ColumnType.merge(
+        columnTypeStringSmall,
+        columnTypeIntBig
       ) shouldBe ColumnTypeString(ColumnLength(2))
       ColumnType.merge(
         columnTypeStringSmall,
@@ -283,6 +352,10 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
       ) shouldBe columnTypeUnknown
       ColumnType.merge(
         columnTypeUnknown,
+        columnTypeShortBig
+      ) shouldBe columnTypeUnknown
+      ColumnType.merge(
+        columnTypeUnknown,
         columnTypeIntBig
       ) shouldBe columnTypeUnknown
       ColumnType.merge(
@@ -312,6 +385,7 @@ class ColumnTypeSpec extends AnyFunSpec with Matchers {
     it("success") {
       ColumnType.apply(false).toSqlSentence shouldBe "BOOLEAN"
       ColumnType.apply(1.toByte).toSqlSentence shouldBe "TINYINT(1)"
+      ColumnType.apply(1.toShort).toSqlSentence shouldBe "SMALLINT(1)"
       ColumnType.apply(1).toSqlSentence shouldBe "INT(1)"
       ColumnType.apply(1.toLong).toSqlSentence shouldBe "INT(1)"
       ColumnType.apply(1.1).toSqlSentence shouldBe "DOUBLE"

--- a/src/test/scala/domain/table/dml/RecordListSpec.scala
+++ b/src/test/scala/domain/table/dml/RecordListSpec.scala
@@ -85,6 +85,9 @@ class RecordListSpec extends AnyFunSpec with Matchers {
       RecordValue(Map(("int", 1))).toSqlSentence shouldBe ("int", "1")
       RecordValue(Map(("long", 1.toLong))).toSqlSentence shouldBe ("long", "1")
       RecordValue(
+        Map(("float", 1.toFloat))
+      ).toSqlSentence shouldBe ("float", "1.0")
+      RecordValue(
         Map(("double", 1.toDouble))
       ).toSqlSentence shouldBe ("double", "1.0")
       RecordValue(

--- a/src/test/scala/domain/table/dml/RecordListSpec.scala
+++ b/src/test/scala/domain/table/dml/RecordListSpec.scala
@@ -84,6 +84,9 @@ class RecordListSpec extends AnyFunSpec with Matchers {
         Map(("double", 1.toDouble))
       ).toSqlSentence shouldBe ("double", "1.0")
       RecordValue(
+        Map(("char", 'a'))
+      ).toSqlSentence shouldBe ("char", "\"a\"")
+      RecordValue(
         Map(("string", 1.toString))
       ).toSqlSentence shouldBe ("string", "\"1\"")
       RecordValue(

--- a/src/test/scala/domain/table/dml/RecordListSpec.scala
+++ b/src/test/scala/domain/table/dml/RecordListSpec.scala
@@ -78,6 +78,7 @@ class RecordListSpec extends AnyFunSpec with Matchers {
       RecordValue(
         Map(("boolean", false))
       ).toSqlSentence shouldBe ("boolean", "false")
+      RecordValue(Map(("byte", 1.toByte))).toSqlSentence shouldBe ("byte", "1")
       RecordValue(Map(("int", 1))).toSqlSentence shouldBe ("int", "1")
       RecordValue(Map(("long", 1.toLong))).toSqlSentence shouldBe ("long", "1")
       RecordValue(

--- a/src/test/scala/domain/table/dml/RecordListSpec.scala
+++ b/src/test/scala/domain/table/dml/RecordListSpec.scala
@@ -79,6 +79,9 @@ class RecordListSpec extends AnyFunSpec with Matchers {
         Map(("boolean", false))
       ).toSqlSentence shouldBe ("boolean", "false")
       RecordValue(Map(("byte", 1.toByte))).toSqlSentence shouldBe ("byte", "1")
+      RecordValue(
+        Map(("short", 1.toShort))
+      ).toSqlSentence shouldBe ("short", "1")
       RecordValue(Map(("int", 1))).toSqlSentence shouldBe ("int", "1")
       RecordValue(Map(("long", 1.toLong))).toSqlSentence shouldBe ("long", "1")
       RecordValue(

--- a/src/test/scala/domain/table/dml/RecordListSpec.scala
+++ b/src/test/scala/domain/table/dml/RecordListSpec.scala
@@ -4,6 +4,8 @@ import domain.table.ddl.TableName
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.util.UUID
+
 class RecordListSpec extends AnyFunSpec with Matchers {
   describe("merge") {
     describe("success") {
@@ -90,6 +92,10 @@ class RecordListSpec extends AnyFunSpec with Matchers {
       RecordValue(
         Map(("double", 1.toDouble))
       ).toSqlSentence shouldBe ("double", "1.0")
+      val uuid = UUID.randomUUID()
+      RecordValue(
+        Map(("uuid", uuid))
+      ).toSqlSentence shouldBe ("uuid", s"\"$uuid\"")
       RecordValue(
         Map(("char", 'a'))
       ).toSqlSentence shouldBe ("char", "\"a\"")


### PR DESCRIPTION
https://github.com/kazumatsudo/GraphDB2RDB/issues/52

https://docs.janusgraph.org/schema/#property-key-data-type

Future works: Geoshape and Date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the range of column types to include Byte, Short, Float, UUID, and Character.
  - Enhanced SQL sentence generation to support new column types.

- **Tests**
  - Added tests to ensure accurate conversion of new data types to SQL sentences.
  - Extended existing tests to cover new column type behaviors and interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->