### PR TITLE
 add: inVertex and outVertex label in edge table

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,18 @@ generate RDB DDL/DML from GraphDB (Tinkerpop).
 ## Features
 
 - this script generate 4 SQL files.
-    1. [DDL] CREATE TABLE "vertex_xxx"
-        - xxx = vertex label
+    1. [DDL] CREATE TABLE "vertex_${vertex label}"
         - the columns are as follows.
             - id
-            - all property keys
-    2. [DDL] CREATE TABLE "edge_xxx"
-        - xxx = edge label
+            - property_${all property keys}
+    2. [DDL] CREATE TABLE "edge_${edge label}_from_${out vertex label}_to_${in vertex label}"
         - the columns are as follows.
            - id  
-           - id_in_v (= vertex_xxx.id)
-           - id_out_v (= vertex_xxx.id)
-           - all property keys
-    3. [DML] INSERT INTO "vertex_xxx"
-        - xxx = vertex label
-    4. [DML] INSERT INTO "edge_xxx"
-        - xxx = edge label
+           - id_in_v (= vertex_{vertex label}.id)
+           - id_out_v (= vertex_{vertex label}.id)
+           - property_${all property keys}
+    3. [DML] INSERT INTO "vertex_${vertex label}"
+    4. [DML] INSERT INTO "edge_${edge label}_from_${out vertex label}_to_${in vertex label}"
 
 ## Prerequisites
 

--- a/src/main/scala/domain/graph/GraphEdge.scala
+++ b/src/main/scala/domain/graph/GraphEdge.scala
@@ -10,8 +10,14 @@ import scala.jdk.CollectionConverters.SetHasAsScala
 
 case class GraphEdge(private val value: Edge, private val config: Config) {
 
+  private val inVertex = value.inVertex()
+  private val inVertexId = inVertex.id()
+  private val inVertexLabel = inVertex.label()
+  private val outVertex = value.outVertex()
+  private val outVertexId = outVertex.id()
+  private val outVertexLabel = outVertex.label()
   private val tableName = TableName(
-    s"${config.tableName.edge}_${value.label()}"
+    s"${config.tableName.edge}_${value.label()}_from_${outVertexLabel}_to_$inVertexLabel"
   )
   private val columnNamePrefixProperty = config.columnName.prefixProperty
 
@@ -30,17 +36,9 @@ case class GraphEdge(private val value: Edge, private val config: Config) {
     TableList {
       val idColumn = Map(ColumnName(columnNameEdgeId) -> ColumnType.apply(id))
       val inVColumn =
-        Map(
-          ColumnName(columnNameEdgeInVId) -> ColumnType.apply(
-            value.inVertex().id()
-          )
-        )
+        Map(ColumnName(columnNameEdgeInVId) -> ColumnType.apply(inVertexId))
       val outVColumn =
-        Map(
-          ColumnName(columnNameEdgeOutVId) -> ColumnType.apply(
-            value.outVertex().id()
-          )
-        )
+        Map(ColumnName(columnNameEdgeOutVId) -> ColumnType.apply(outVertexId))
 
       // TODO: pull request for gremlin-scala
       val propertyColumn = value
@@ -70,11 +68,10 @@ case class GraphEdge(private val value: Edge, private val config: Config) {
       }
       .toMap
 
-    val recordValue = Map(columnNameEdgeId -> value.id()) ++ Map(
-      columnNameEdgeInVId -> value.inVertex().id()
-    ) ++ Map(
-      columnNameEdgeOutVId -> value.outVertex().id()
-    ) ++ propertyColumnList
+    val recordValue = Map(columnNameEdgeId -> value.id()) ++
+      Map(columnNameEdgeInVId -> inVertexId) ++
+      Map(columnNameEdgeOutVId -> outVertexId) ++
+      propertyColumnList
 
     RecordList(
       Map(RecordKey(tableName, RecordId(id)) -> RecordValue(recordValue))

--- a/src/test/scala/domain/graph/GraphEdgeSpec.scala
+++ b/src/test/scala/domain/graph/GraphEdgeSpec.scala
@@ -28,7 +28,7 @@ class GraphEdgeSpec extends AsyncFunSpec with Matchers {
       edge.map {
         _.head.toDdl shouldBe TableList(
           Map(
-            TableName("edge_knows") -> ColumnList(
+            TableName("edge_knows_from_person_to_person") -> ColumnList(
               Map(
                 ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
                 ColumnName("id_in_v") -> ColumnTypeInt(ColumnLength(1)),
@@ -53,7 +53,9 @@ class GraphEdgeSpec extends AsyncFunSpec with Matchers {
       edge.map {
         _.head.toDml shouldBe RecordList(
           Map(
-            RecordKey((TableName("edge_knows"), RecordId(7))) -> RecordValue(
+            RecordKey(
+              (TableName("edge_knows_from_person_to_person"), RecordId(7))
+            ) -> RecordValue(
               Map(
                 "id" -> 7,
                 "id_in_v" -> 2,
@@ -75,7 +77,12 @@ class GraphEdgeSpec extends AsyncFunSpec with Matchers {
       val graphEdge = GraphEdge(edge, config)
       graphEdge.toDml shouldBe RecordList(
         Map(
-          RecordKey((TableName("edge_testEdge"), RecordId(14))) -> RecordValue(
+          RecordKey(
+            (
+              TableName("edge_testEdge_from_testVertex1_to_testVertex2"),
+              RecordId(14)
+            )
+          ) -> RecordValue(
             Map("id" -> 14, "id_in_v" -> 13, "id_out_v" -> 0)
           )
         )

--- a/src/test/scala/usecase/ByExhaustiveSearchSpec.scala
+++ b/src/test/scala/usecase/ByExhaustiveSearchSpec.scala
@@ -15,6 +15,8 @@ import org.scalatest.funspec.AsyncFunSpec
 import org.scalatest.matchers.should.Matchers
 import utils.Config
 
+import scala.collection.immutable.HashMap
+
 class ByExhaustiveSearchSpec extends AsyncFunSpec with Matchers {
   private val config = Config.default
 
@@ -30,88 +32,70 @@ class ByExhaustiveSearchSpec extends AsyncFunSpec with Matchers {
               TableName("vertex_person") -> ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
-                  ColumnName("property_age") -> ColumnTypeInt(
-                    ColumnLength(2)
-                  ),
                   ColumnName("property_name") -> ColumnTypeString(
                     ColumnLength(5)
-                  )
+                  ),
+                  ColumnName("property_age") -> ColumnTypeInt(ColumnLength(2))
                 )
               ),
               TableName("vertex_software") -> ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
-                  ColumnName("property_lang") -> ColumnTypeString(
-                    ColumnLength(4)
-                  ),
                   ColumnName("property_name") -> ColumnTypeString(
                     ColumnLength(6)
+                  ),
+                  ColumnName("property_lang") -> ColumnTypeString(
+                    ColumnLength(4)
                   )
                 )
               )
             )
           ),
           RecordList(
-            Map(
+            HashMap(
+              RecordKey(
+                (TableName("vertex_software"), RecordId(5))
+              ) -> RecordValue(
+                Map(
+                  "id" -> 5,
+                  "property_name" -> "ripple",
+                  "property_lang" -> "java"
+                )
+              ),
               RecordKey(
                 (TableName("vertex_person"), RecordId(1))
               ) -> RecordValue(
-                Map(
-                  "id" -> 1,
-                  "property_age" -> 29,
-                  "property_name" -> "marko"
-                )
-              ),
-              RecordKey(
-                (TableName("vertex_person"), RecordId(2))
-              ) -> RecordValue(
-                Map(
-                  "id" -> 2,
-                  "property_age" -> 27,
-                  "property_name" -> "vadas"
-                )
-              ),
-              RecordKey(
-                (TableName("vertex_person"), RecordId(4))
-              ) -> RecordValue(
-                Map(
-                  "id" -> 4,
-                  "property_age" -> 32,
-                  "property_name" -> "josh"
-                )
-              ),
-              RecordKey(
-                (TableName("vertex_person"), RecordId(6))
-              ) -> RecordValue(
-                Map(
-                  "id" -> 6,
-                  "property_age" -> 35,
-                  "property_name" -> "peter"
-                )
+                Map("id" -> 1, "property_name" -> "marko", "property_age" -> 29)
               ),
               RecordKey(
                 (TableName("vertex_software"), RecordId(3))
               ) -> RecordValue(
                 Map(
                   "id" -> 3,
-                  "property_lang" -> "java",
-                  "property_name" -> "lop"
+                  "property_name" -> "lop",
+                  "property_lang" -> "java"
                 )
               ),
               RecordKey(
-                (TableName("vertex_software"), RecordId(5))
+                (TableName("vertex_person"), RecordId(2))
               ) -> RecordValue(
-                Map(
-                  "id" -> 5,
-                  "property_lang" -> "java",
-                  "property_name" -> "ripple"
-                )
+                Map("id" -> 2, "property_name" -> "vadas", "property_age" -> 27)
+              ),
+              RecordKey(
+                (TableName("vertex_person"), RecordId(6))
+              ) -> RecordValue(
+                Map("id" -> 6, "property_name" -> "peter", "property_age" -> 35)
+              ),
+              RecordKey(
+                (TableName("vertex_person"), RecordId(4))
+              ) -> RecordValue(
+                Map("id" -> 4, "property_name" -> "josh", "property_age" -> 32)
               )
             )
           ),
           TableList(
             Map(
-              TableName("edge_created") -> ColumnList(
+              TableName("edge_created_from_person_to_software") -> ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(2)),
                   ColumnName("id_in_v") -> ColumnTypeInt(ColumnLength(1)),
@@ -121,7 +105,7 @@ class ByExhaustiveSearchSpec extends AsyncFunSpec with Matchers {
                   )
                 )
               ),
-              TableName("edge_knows") -> ColumnList(
+              TableName("edge_knows_from_person_to_person") -> ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
                   ColumnName("id_in_v") -> ColumnTypeInt(ColumnLength(1)),
@@ -134,49 +118,12 @@ class ByExhaustiveSearchSpec extends AsyncFunSpec with Matchers {
             )
           ),
           RecordList(
-            Map(
+            HashMap(
               RecordKey(
-                (TableName("edge_knows"), RecordId(7))
-              ) -> RecordValue(
-                Map(
-                  "id" -> 7,
-                  "id_in_v" -> 2,
-                  "id_out_v" -> 1,
-                  "property_weight" -> 0.5
+                (
+                  TableName("edge_created_from_person_to_software"),
+                  RecordId(11)
                 )
-              ),
-              RecordKey(
-                (TableName("edge_knows"), RecordId(8))
-              ) -> RecordValue(
-                Map(
-                  "id" -> 8,
-                  "id_in_v" -> 4,
-                  "id_out_v" -> 1,
-                  "property_weight" -> 1.0
-                )
-              ),
-              RecordKey(
-                (TableName("edge_created"), RecordId(9))
-              ) -> RecordValue(
-                Map(
-                  "id" -> 9,
-                  "id_in_v" -> 3,
-                  "id_out_v" -> 1,
-                  "property_weight" -> 0.4
-                )
-              ),
-              RecordKey(
-                (TableName("edge_created"), RecordId(10))
-              ) -> RecordValue(
-                Map(
-                  "id" -> 10,
-                  "id_in_v" -> 5,
-                  "id_out_v" -> 4,
-                  "property_weight" -> 1.0
-                )
-              ),
-              RecordKey(
-                (TableName("edge_created"), RecordId(11))
               ) -> RecordValue(
                 Map(
                   "id" -> 11,
@@ -186,13 +133,59 @@ class ByExhaustiveSearchSpec extends AsyncFunSpec with Matchers {
                 )
               ),
               RecordKey(
-                (TableName("edge_created"), RecordId(12))
+                (TableName("edge_knows_from_person_to_person"), RecordId(7))
+              ) -> RecordValue(
+                Map(
+                  "id" -> 7,
+                  "id_in_v" -> 2,
+                  "id_out_v" -> 1,
+                  "property_weight" -> 0.5
+                )
+              ),
+              RecordKey(
+                (
+                  TableName("edge_created_from_person_to_software"),
+                  RecordId(10)
+                )
+              ) -> RecordValue(
+                Map(
+                  "id" -> 10,
+                  "id_in_v" -> 5,
+                  "id_out_v" -> 4,
+                  "property_weight" -> 1.0
+                )
+              ),
+              RecordKey(
+                (TableName("edge_created_from_person_to_software"), RecordId(9))
+              ) -> RecordValue(
+                Map(
+                  "id" -> 9,
+                  "id_in_v" -> 3,
+                  "id_out_v" -> 1,
+                  "property_weight" -> 0.4
+                )
+              ),
+              RecordKey(
+                (
+                  TableName("edge_created_from_person_to_software"),
+                  RecordId(12)
+                )
               ) -> RecordValue(
                 Map(
                   "id" -> 12,
                   "id_in_v" -> 3,
                   "id_out_v" -> 6,
                   "property_weight" -> 0.2
+                )
+              ),
+              RecordKey(
+                (TableName("edge_knows_from_person_to_person"), RecordId(8))
+              ) -> RecordValue(
+                Map(
+                  "id" -> 8,
+                  "id_in_v" -> 4,
+                  "id_out_v" -> 1,
+                  "property_weight" -> 1.0
                 )
               )
             )

--- a/src/test/scala/usecase/UsingSpecificKeyListSpec.scala
+++ b/src/test/scala/usecase/UsingSpecificKeyListSpec.scala
@@ -39,10 +39,10 @@ class UsingSpecificKeyListSpec extends AsyncFunSpec with Matchers {
               TableName("vertex_person") -> ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
-                  ColumnName("property_age") -> ColumnTypeInt(ColumnLength(2)),
                   ColumnName("property_name") -> ColumnTypeString(
                     ColumnLength(5)
-                  )
+                  ),
+                  ColumnName("property_age") -> ColumnTypeInt(ColumnLength(2))
                 )
               )
             )
@@ -52,13 +52,13 @@ class UsingSpecificKeyListSpec extends AsyncFunSpec with Matchers {
               RecordKey(
                 (TableName("vertex_person"), RecordId(1))
               ) -> RecordValue(
-                Map("id" -> 1, "property_age" -> 29, "property_name" -> "marko")
+                Map("id" -> 1, "property_name" -> "marko", "property_age" -> 29)
               )
             )
           ),
           TableList(
             Map(
-              TableName("edge_created") -> ColumnList(
+              TableName("edge_knows_from_person_to_person") -> ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
                   ColumnName("id_in_v") -> ColumnTypeInt(ColumnLength(1)),
@@ -68,7 +68,7 @@ class UsingSpecificKeyListSpec extends AsyncFunSpec with Matchers {
                   )
                 )
               ),
-              TableName("edge_knows") -> ColumnList(
+              TableName("edge_created_from_person_to_software") -> ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
                   ColumnName("id_in_v") -> ColumnTypeInt(ColumnLength(1)),
@@ -82,15 +82,9 @@ class UsingSpecificKeyListSpec extends AsyncFunSpec with Matchers {
           ),
           RecordList(
             Map(
-              RecordKey((TableName("edge_knows"), RecordId(7))) -> RecordValue(
-                Map(
-                  "id" -> 7,
-                  "id_in_v" -> 2,
-                  "id_out_v" -> 1,
-                  "property_weight" -> 0.5
-                )
-              ),
-              RecordKey((TableName("edge_knows"), RecordId(8))) -> RecordValue(
+              RecordKey(
+                (TableName("edge_knows_from_person_to_person"), RecordId(8))
+              ) -> RecordValue(
                 Map(
                   "id" -> 8,
                   "id_in_v" -> 4,
@@ -99,7 +93,17 @@ class UsingSpecificKeyListSpec extends AsyncFunSpec with Matchers {
                 )
               ),
               RecordKey(
-                (TableName("edge_created"), RecordId(9))
+                (TableName("edge_knows_from_person_to_person"), RecordId(7))
+              ) -> RecordValue(
+                Map(
+                  "id" -> 7,
+                  "id_in_v" -> 2,
+                  "id_out_v" -> 1,
+                  "property_weight" -> 0.5
+                )
+              ),
+              RecordKey(
+                (TableName("edge_created_from_person_to_software"), RecordId(9))
               ) -> RecordValue(
                 Map(
                   "id" -> 9,


### PR DESCRIPTION
https://github.com/kazumatsudo/GraphDB2RDB/issues/103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated script to dynamically generate SQL files for graph database tables and data insertion, reflecting the structure of the graph.

- **Enhancements**
	- Improved the `GraphEdge` class to better encapsulate vertex information and facilitate table name construction based on vertex labels.

- **Tests**
	- Modified test cases in `GraphEdgeSpec.scala` to include more descriptive table and record names for edge relationships.
	- Updated `ByExhaustiveSearchSpec` and `UsingSpecificKeyListSpec` test cases to reflect the new structure and naming for tables and records.

- **Documentation**
	- Updated README to describe the dynamic generation of SQL files and the rationale behind the changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->