### PR TITLE
fix: substring table name

### DIFF
--- a/src/main/scala/domain/table/ddl/TableName.scala
+++ b/src/main/scala/domain/table/ddl/TableName.scala
@@ -1,5 +1,10 @@
 package domain.table.ddl
 
 case class TableName(private val value: String) extends AnyVal {
-  def toSqlSentence: String = value
+  private def maxLength = 64
+
+  def toSqlSentence: String = if (value.length > maxLength) {
+    value.substring(0, maxLength)
+  } else
+    value
 }

--- a/src/test/scala/domain/table/ddl/TableNameSpec.scala
+++ b/src/test/scala/domain/table/ddl/TableNameSpec.scala
@@ -1,0 +1,20 @@
+package domain.table.ddl
+
+import org.scalatest.funspec.AsyncFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class TableNameSpec extends AsyncFunSpec with Matchers {
+  describe("toSqlSentence") {
+    it("if the length is less than 64, return as is") {
+      val tableName = "a" * 64
+      TableName(tableName).toSqlSentence shouldBe tableName
+    }
+
+    it(
+      "if the length is 64 or more, return the truncated one after 65 truncated"
+    ) {
+      val tableName = "a" * 65
+      TableName(tableName).toSqlSentence shouldBe tableName.substring(0, 64)
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the SQL sentence creation process by ensuring table names do not exceed 64 characters.
- **Tests**
	- Added tests to verify the truncation of table names in SQL sentence creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->