### PR TITLE
set vertex.id and edge.id primary key

### DIFF
--- a/src/main/scala/domain/graph/GraphEdge.scala
+++ b/src/main/scala/domain/graph/GraphEdge.scala
@@ -1,7 +1,8 @@
 package domain.graph
 
+import domain.table.ddl.attribute.PrimaryKey
 import domain.table.ddl.column.{ColumnList, ColumnName, ColumnType}
-import domain.table.ddl.{TableList, TableName}
+import domain.table.ddl.{TableAttributes, TableList, TableName}
 import domain.table.dml.{RecordId, RecordKey, RecordList, RecordValue}
 import gremlin.scala.Edge
 import utils.Config
@@ -53,8 +54,11 @@ case class GraphEdge(private val value: Edge, private val config: Config)
         .toMap
 
       Map(
-        tableName -> ColumnList(
-          idColumn ++ inVColumn ++ outVColumn ++ propertyColumn
+        tableName -> (
+          ColumnList(
+            idColumn ++ inVColumn ++ outVColumn ++ propertyColumn
+          ),
+          TableAttributes(PrimaryKey(Set(ColumnName(columnNameEdgeId))))
         )
       )
     }

--- a/src/main/scala/domain/graph/GraphVertex.scala
+++ b/src/main/scala/domain/graph/GraphVertex.scala
@@ -1,7 +1,8 @@
 package domain.graph
 
+import domain.table.ddl.attribute.PrimaryKey
 import domain.table.ddl.column.{ColumnList, ColumnName, ColumnType}
-import domain.table.ddl.{TableList, TableName}
+import domain.table.ddl.{TableAttributes, TableList, TableName}
 import domain.table.dml.{RecordId, RecordKey, RecordList, RecordValue}
 import gremlin.scala._
 import utils.Config
@@ -29,7 +30,10 @@ case class GraphVertex(private val value: Vertex, private val config: Config)
       val propertyColumn = value.valueMap.map { case (key, value) =>
         ColumnName(s"$columnNamePrefixProperty$key") -> ColumnType.apply(value)
       }
-      Map(tableName -> ColumnList(idColumn ++ propertyColumn))
+      Map(
+        tableName -> (ColumnList(idColumn ++ propertyColumn),
+        TableAttributes(PrimaryKey(Set(ColumnName(columnNameVertexId)))))
+      )
     }
 
   override def toDml: RecordList = {

--- a/src/main/scala/domain/table/ddl/TableAttributes.scala
+++ b/src/main/scala/domain/table/ddl/TableAttributes.scala
@@ -1,0 +1,19 @@
+package domain.table.ddl
+
+import domain.table.ddl.attribute.PrimaryKey
+
+final case class TableAttributes(private val primaryKey: PrimaryKey) {
+
+  /** merges TableAttribute in two table attributes into one
+    *
+    * @param target
+    *   target TableAttribute
+    * @return
+    *   merged TableAttribute
+    */
+  def merge(target: TableAttributes): TableAttributes = TableAttributes(
+    primaryKey.merge(target.primaryKey)
+  )
+
+  def toSqlSentenceSeq: Seq[String] = Seq(primaryKey.toSqlSentence)
+}

--- a/src/main/scala/domain/table/ddl/TableList.scala
+++ b/src/main/scala/domain/table/ddl/TableList.scala
@@ -4,8 +4,9 @@ import domain.table.ddl.column.ColumnList
 
 import scala.collection.View
 
-case class TableList(private val value: Map[TableName, ColumnList])
-    extends AnyVal {
+case class TableList(
+    private val value: Map[TableName, (ColumnList, TableAttributes)]
+) extends AnyVal {
 
   /** merges tableList in two Tables into one
     *
@@ -17,20 +18,27 @@ case class TableList(private val value: Map[TableName, ColumnList])
   def merge(target: TableList): TableList =
     TableList {
       value.foldLeft(target.value) { (accumulator, currentValue) =>
-        val (tableName, columnList) = currentValue
+        val (tableName, (columnList, tableAttribute)) = currentValue
 
         accumulator.updated(
           tableName,
           accumulator
             .get(tableName)
-            .map(_.merge(columnList))
-            .getOrElse(columnList)
+            .map { case (accumulatorColumnList, accumulatorTableAttribute) =>
+              (
+                accumulatorColumnList.merge(columnList),
+                accumulatorTableAttribute.merge(tableAttribute)
+              )
+            }
+            .getOrElse((columnList, tableAttribute))
         )
       }
     }
 
-  def toSqlSentence: View[String] = value.map { case (tableName, columnList) =>
-    s"CREATE TABLE IF NOT EXISTS ${tableName.toSqlSentence} (${columnList.toSqlSentence});"
+  def toSqlSentence: View[String] = value.map {
+    case (tableName, (columnList, tableAttribute)) =>
+      s"CREATE TABLE IF NOT EXISTS ${tableName.toSqlSentence} (${(columnList.toSqlSentenceSeq ++ tableAttribute.toSqlSentenceSeq)
+          .mkString(", ")});"
   }.view
 
 }

--- a/src/main/scala/domain/table/ddl/attribute/PrimaryKey.scala
+++ b/src/main/scala/domain/table/ddl/attribute/PrimaryKey.scala
@@ -1,0 +1,24 @@
+package domain.table.ddl.attribute
+
+import domain.table.ddl.column.ColumnName
+
+case class PrimaryKey(private val value: Set[ColumnName]) extends AnyVal {
+
+  /** merges PrimaryKey in two primary key list into one
+    *
+    * @param target
+    *   target PrimaryKey
+    * @return
+    *   merged primary key list
+    */
+  def merge(target: PrimaryKey): PrimaryKey = if (value == target.value) {
+    this
+  } else {
+    throw new IllegalArgumentException(
+      s"primary key must be unique. detected values: $value and ${target.value}"
+    )
+  }
+
+  def toSqlSentence: String =
+    s"PRIMARY KEY (${value.toSeq.sortBy(_.toSqlSentence).map(_.toSqlSentence).mkString(", ")})"
+}

--- a/src/main/scala/domain/table/ddl/column/ColumnList.scala
+++ b/src/main/scala/domain/table/ddl/column/ColumnList.scala
@@ -25,11 +25,10 @@ case class ColumnList(private val value: Map[ColumnName, ColumnType])
       }
     }
 
-  def toSqlSentence: String =
+  def toSqlSentenceSeq: Seq[String] =
     value.toSeq
       .sortBy { case (columnName, _) => columnName.toSqlSentence }
       .map { case (columnName, columnType) =>
         s"${columnName.toSqlSentence} ${columnType.toSqlSentence}"
       }
-      .mkString(", ")
 }

--- a/src/test/scala/domain/graph/GraphEdgeSpec.scala
+++ b/src/test/scala/domain/graph/GraphEdgeSpec.scala
@@ -1,5 +1,6 @@
 package domain.graph
 
+import domain.table.ddl.attribute.PrimaryKey
 import domain.table.ddl.column.{
   ColumnLength,
   ColumnList,
@@ -7,7 +8,7 @@ import domain.table.ddl.column.{
   ColumnTypeDouble,
   ColumnTypeInt
 }
-import domain.table.ddl.{TableList, TableName}
+import domain.table.ddl.{TableAttributes, TableList, TableName}
 import domain.table.dml.{RecordId, RecordKey, RecordList, RecordValue}
 import infrastructure.EdgeQuery
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.V
@@ -28,7 +29,7 @@ class GraphEdgeSpec extends AsyncFunSpec with Matchers {
       edge.map {
         _.head.toDdl shouldBe TableList(
           Map(
-            TableName("edge_knows_from_person_to_person") -> ColumnList(
+            TableName("edge_knows_from_person_to_person") -> (ColumnList(
               Map(
                 ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
                 ColumnName("id_in_v") -> ColumnTypeInt(ColumnLength(1)),
@@ -37,7 +38,7 @@ class GraphEdgeSpec extends AsyncFunSpec with Matchers {
                   ColumnLength(3)
                 )
               )
-            )
+            ), TableAttributes(PrimaryKey(Set(ColumnName("id")))))
           )
         )
       }

--- a/src/test/scala/domain/graph/GraphVertexSpec.scala
+++ b/src/test/scala/domain/graph/GraphVertexSpec.scala
@@ -1,5 +1,6 @@
 package domain.graph
 
+import domain.table.ddl.attribute.PrimaryKey
 import domain.table.ddl.column.{
   ColumnLength,
   ColumnList,
@@ -7,7 +8,7 @@ import domain.table.ddl.column.{
   ColumnTypeInt,
   ColumnTypeString
 }
-import domain.table.ddl.{TableList, TableName}
+import domain.table.ddl.{TableAttributes, TableList, TableName}
 import domain.table.dml.{RecordId, RecordKey, RecordList, RecordValue}
 import infrastructure.VertexQuery
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory
@@ -27,13 +28,15 @@ class GraphVertexSpec extends AsyncFunSpec with Matchers {
       vertex.map {
         _.head.toDdl shouldBe TableList(
           Map(
-            TableName("vertex_person") -> ColumnList(
+            TableName("vertex_person") -> (ColumnList(
               Map(
                 ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
-                ColumnName("property_age") -> ColumnTypeInt(ColumnLength(2)),
-                ColumnName("property_name") -> ColumnTypeString(ColumnLength(5))
+                ColumnName("property_name") -> ColumnTypeString(
+                  ColumnLength(5)
+                ),
+                ColumnName("property_age") -> ColumnTypeInt(ColumnLength(2))
               )
-            )
+            ), TableAttributes(PrimaryKey(Set(ColumnName("id")))))
           )
         )
       }

--- a/src/test/scala/domain/table/ddl/TableAttributesSpec.scala
+++ b/src/test/scala/domain/table/ddl/TableAttributesSpec.scala
@@ -1,0 +1,27 @@
+package domain.table.ddl
+
+import domain.table.ddl.attribute.PrimaryKey
+import domain.table.ddl.column.ColumnName
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class TableAttributesSpec extends AnyFunSpec with Matchers {
+  describe("merge") {
+    it("success") {
+      val primaryKey = PrimaryKey(Set(ColumnName("test1")))
+      val tableAttributes = TableAttributes(primaryKey)
+      val target = TableAttributes(primaryKey)
+
+      tableAttributes.merge(target) shouldBe tableAttributes
+    }
+  }
+
+  describe("toSqlSentenceSeq") {
+    it("success") {
+      val primaryKey = PrimaryKey(Set(ColumnName("test1")))
+      val tableAttributes = TableAttributes(primaryKey)
+
+      tableAttributes.toSqlSentenceSeq shouldBe List("PRIMARY KEY (test1)")
+    }
+  }
+}

--- a/src/test/scala/domain/table/ddl/TableListSpec.scala
+++ b/src/test/scala/domain/table/ddl/TableListSpec.scala
@@ -1,5 +1,6 @@
 package domain.table.ddl
 
+import domain.table.ddl.attribute.PrimaryKey
 import domain.table.ddl.column._
 import infrastructure.VertexQuery
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory
@@ -25,20 +26,20 @@ class TableListSpec extends AsyncFunSpec with Matchers {
           }
       } yield result shouldBe TableList(
         Map(
-          TableName("vertex_person") -> ColumnList(
+          TableName("vertex_person") -> (ColumnList(
             Map(
               ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
-              ColumnName("property_age") -> ColumnTypeInt(ColumnLength(2)),
-              ColumnName("property_name") -> ColumnTypeString(ColumnLength(5))
+              ColumnName("property_name") -> ColumnTypeString(ColumnLength(5)),
+              ColumnName("property_age") -> ColumnTypeInt(ColumnLength(2))
             )
-          ),
-          TableName("vertex_software") -> ColumnList(
+          ), TableAttributes(PrimaryKey(Set(ColumnName("id"))))),
+          TableName("vertex_software") -> (ColumnList(
             Map(
               ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
-              ColumnName("property_lang") -> ColumnTypeString(ColumnLength(4)),
-              ColumnName("property_name") -> ColumnTypeString(ColumnLength(6))
+              ColumnName("property_name") -> ColumnTypeString(ColumnLength(6)),
+              ColumnName("property_lang") -> ColumnTypeString(ColumnLength(4))
             )
-          )
+          ), TableAttributes(PrimaryKey(Set(ColumnName("id")))))
         )
       )
     }
@@ -60,20 +61,20 @@ class TableListSpec extends AsyncFunSpec with Matchers {
           }
       } yield result shouldBe TableList(
         Map(
-          TableName("vertex_person") -> ColumnList(
+          TableName("vertex_person") -> (ColumnList(
             Map(
               ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
               ColumnName("property_name") -> ColumnTypeString(ColumnLength(5)),
               ColumnName("property_age") -> ColumnTypeInt(ColumnLength(2))
             )
-          ),
-          TableName("vertex_software") -> ColumnList(
+          ), TableAttributes(PrimaryKey(Set(ColumnName("id"))))),
+          TableName("vertex_software") -> (ColumnList(
             Map(
               ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
               ColumnName("property_name") -> ColumnTypeString(ColumnLength(6)),
               ColumnName("property_lang") -> ColumnTypeString(ColumnLength(4))
             )
-          )
+          ), TableAttributes(PrimaryKey(Set(ColumnName("id")))))
         )
       )
     }

--- a/src/test/scala/domain/table/ddl/attribute/PrimaryKeySpec.scala
+++ b/src/test/scala/domain/table/ddl/attribute/PrimaryKeySpec.scala
@@ -1,0 +1,34 @@
+package domain.table.ddl.attribute
+
+import domain.table.ddl.column.ColumnName
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class PrimaryKeySpec extends AnyFunSpec with Matchers {
+  describe("merge") {
+    it("success when the two values are the same.") {
+      val value = Set(ColumnName("test1"), ColumnName("test2"))
+      val primaryKey = PrimaryKey(value)
+      primaryKey.merge(primaryKey) shouldBe primaryKey
+    }
+
+    it("fail when the two values are not the same.") {
+      val value1 = Set(ColumnName("test1"), ColumnName("test2"))
+      val primaryKey1 = PrimaryKey(value1)
+      val value2 = Set(ColumnName("test1"), ColumnName("test3"))
+      val primaryKey2 = PrimaryKey(value2)
+
+      intercept[IllegalArgumentException] {
+        primaryKey1.merge(primaryKey2)
+      }
+    }
+  }
+
+  describe("toSqlSentence") {
+    it("generate SQL Sentence") {
+      val value = Set(ColumnName("test1"), ColumnName("test2"))
+      val primaryKey = PrimaryKey(value)
+      primaryKey.toSqlSentence shouldBe "PRIMARY KEY (test1, test2)"
+    }
+  }
+}

--- a/src/test/scala/domain/table/ddl/column/ColumnListSpec.scala
+++ b/src/test/scala/domain/table/ddl/column/ColumnListSpec.scala
@@ -46,11 +46,15 @@ class ColumnListSpec extends AnyFunSpec with Matchers {
     }
   }
 
-  describe("toSqlSentence") {
+  describe("toSqlSentenceSeq") {
     it("success") {
-      columnList1
-        .merge(columnList2)
-        .toSqlSentence shouldBe "address VARCHAR(255), created_at TEXT, id INT, name VARCHAR(50), updated_at TEXT"
+      columnList1.merge(columnList2).toSqlSentenceSeq shouldBe List(
+        "address VARCHAR(255)",
+        "created_at TEXT",
+        "id INT",
+        "name VARCHAR(50)",
+        "updated_at TEXT"
+      )
     }
   }
 }

--- a/src/test/scala/usecase/ByExhaustiveSearchSpec.scala
+++ b/src/test/scala/usecase/ByExhaustiveSearchSpec.scala
@@ -1,5 +1,6 @@
 package usecase
 
+import domain.table.ddl.attribute.PrimaryKey
 import domain.table.ddl.column.{
   ColumnLength,
   ColumnList,
@@ -8,7 +9,7 @@ import domain.table.ddl.column.{
   ColumnTypeInt,
   ColumnTypeString
 }
-import domain.table.ddl.{TableList, TableName}
+import domain.table.ddl.{TableAttributes, TableList, TableName}
 import domain.table.dml.{RecordId, RecordKey, RecordList, RecordValue}
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory
 import org.scalatest.funspec.AsyncFunSpec
@@ -29,7 +30,7 @@ class ByExhaustiveSearchSpec extends AsyncFunSpec with Matchers {
         _ shouldBe UsecaseResponse(
           TableList(
             Map(
-              TableName("vertex_person") -> ColumnList(
+              TableName("vertex_person") -> (ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
                   ColumnName("property_name") -> ColumnTypeString(
@@ -37,8 +38,8 @@ class ByExhaustiveSearchSpec extends AsyncFunSpec with Matchers {
                   ),
                   ColumnName("property_age") -> ColumnTypeInt(ColumnLength(2))
                 )
-              ),
-              TableName("vertex_software") -> ColumnList(
+              ), TableAttributes(PrimaryKey(Set(ColumnName("id"))))),
+              TableName("vertex_software") -> (ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
                   ColumnName("property_name") -> ColumnTypeString(
@@ -48,7 +49,7 @@ class ByExhaustiveSearchSpec extends AsyncFunSpec with Matchers {
                     ColumnLength(4)
                   )
                 )
-              )
+              ), TableAttributes(PrimaryKey(Set(ColumnName("id")))))
             )
           ),
           RecordList(
@@ -95,7 +96,7 @@ class ByExhaustiveSearchSpec extends AsyncFunSpec with Matchers {
           ),
           TableList(
             Map(
-              TableName("edge_created_from_person_to_software") -> ColumnList(
+              TableName("edge_created_from_person_to_software") -> (ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(2)),
                   ColumnName("id_in_v") -> ColumnTypeInt(ColumnLength(1)),
@@ -104,8 +105,8 @@ class ByExhaustiveSearchSpec extends AsyncFunSpec with Matchers {
                     ColumnLength(3)
                   )
                 )
-              ),
-              TableName("edge_knows_from_person_to_person") -> ColumnList(
+              ), TableAttributes(PrimaryKey(Set(ColumnName("id"))))),
+              TableName("edge_knows_from_person_to_person") -> (ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
                   ColumnName("id_in_v") -> ColumnTypeInt(ColumnLength(1)),
@@ -114,7 +115,7 @@ class ByExhaustiveSearchSpec extends AsyncFunSpec with Matchers {
                     ColumnLength(3)
                   )
                 )
-              )
+              ), TableAttributes(PrimaryKey(Set(ColumnName("id")))))
             )
           ),
           RecordList(

--- a/src/test/scala/usecase/UsingSpecificKeyListSpec.scala
+++ b/src/test/scala/usecase/UsingSpecificKeyListSpec.scala
@@ -1,5 +1,6 @@
 package usecase
 
+import domain.table.ddl.attribute.PrimaryKey
 import domain.table.ddl.column.{
   ColumnLength,
   ColumnList,
@@ -8,7 +9,7 @@ import domain.table.ddl.column.{
   ColumnTypeInt,
   ColumnTypeString
 }
-import domain.table.ddl.{TableList, TableName}
+import domain.table.ddl.{TableAttributes, TableList, TableName}
 import domain.table.dml.{RecordId, RecordKey, RecordList, RecordValue}
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory
 import org.scalatest.funspec.AsyncFunSpec
@@ -36,7 +37,7 @@ class UsingSpecificKeyListSpec extends AsyncFunSpec with Matchers {
         _ shouldBe UsecaseResponse(
           TableList(
             Map(
-              TableName("vertex_person") -> ColumnList(
+              TableName("vertex_person") -> (ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
                   ColumnName("property_name") -> ColumnTypeString(
@@ -44,7 +45,7 @@ class UsingSpecificKeyListSpec extends AsyncFunSpec with Matchers {
                   ),
                   ColumnName("property_age") -> ColumnTypeInt(ColumnLength(2))
                 )
-              )
+              ), TableAttributes(PrimaryKey(Set(ColumnName("id")))))
             )
           ),
           RecordList(
@@ -58,7 +59,7 @@ class UsingSpecificKeyListSpec extends AsyncFunSpec with Matchers {
           ),
           TableList(
             Map(
-              TableName("edge_knows_from_person_to_person") -> ColumnList(
+              TableName("edge_knows_from_person_to_person") -> (ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
                   ColumnName("id_in_v") -> ColumnTypeInt(ColumnLength(1)),
@@ -67,8 +68,8 @@ class UsingSpecificKeyListSpec extends AsyncFunSpec with Matchers {
                     ColumnLength(3)
                   )
                 )
-              ),
-              TableName("edge_created_from_person_to_software") -> ColumnList(
+              ), TableAttributes(PrimaryKey(Set(ColumnName("id"))))),
+              TableName("edge_created_from_person_to_software") -> (ColumnList(
                 Map(
                   ColumnName("id") -> ColumnTypeInt(ColumnLength(1)),
                   ColumnName("id_in_v") -> ColumnTypeInt(ColumnLength(1)),
@@ -77,7 +78,7 @@ class UsingSpecificKeyListSpec extends AsyncFunSpec with Matchers {
                     ColumnLength(3)
                   )
                 )
-              )
+              ), TableAttributes(PrimaryKey(Set(ColumnName("id")))))
             )
           ),
           RecordList(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `TableAttributes` class to represent and manage attributes of database tables, including primary keys.
	- Enhanced SQL sentence generation with the inclusion of table attributes.
- **Refactor**
	- Updated `GraphEdge` and `GraphVertex` to utilize `TableAttributes`.
	- Renamed and modified the `toSqlSentence` method in `ColumnList` to `toSqlSentenceSeq` for improved clarity and functionality.
- **Tests**
	- Added comprehensive test cases for new functionalities in `TableAttributes`, `PrimaryKey`, and modified SQL sentence generation.
- **Documentation**
	- Updated documentation to reflect changes in table attribute handling and SQL sentence generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->